### PR TITLE
OnDemandAccounts model and mixin for xml serialization

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,8 +2,8 @@ plugins {
   id "idea"
   id "com.github.mxenabled.binks" version "0.0.1"
   id "com.github.mxenabled.vogue" version "1.0.1"
-  id "com.github.mxenabled.coppuccino" version "3.0.4" apply false
-  id "com.github.mxenabled.hush" version "2.2.0" apply false
+  id "com.github.mxenabled.coppuccino" version "3.1.2" apply false
+  id "com.github.mxenabled.hush" version "2.3.0" apply false
   id "io.freefair.lombok" version "6.5.1" apply false
 }
 

--- a/mdx-models/src/main/java/com/mx/models/Resources.java
+++ b/mdx-models/src/main/java/com/mx/models/Resources.java
@@ -11,6 +11,7 @@ import com.mx.models.account.AccountNumbers;
 import com.mx.models.account.AccountOwner;
 import com.mx.models.account.AccountOwnerDetails;
 import com.mx.models.account.AccountTransactions;
+import com.mx.models.account.OnDemandAccounts;
 import com.mx.models.account.Transaction;
 import com.mx.models.account.TransactionsPage;
 import com.mx.models.ach_transfer.AchAccount;
@@ -48,6 +49,7 @@ import com.mx.models.ondemand.mixins.AccountOwnerXmlMixin;
 import com.mx.models.ondemand.mixins.AccountTransactionsMixIn;
 import com.mx.models.ondemand.mixins.AccountXmlMixin;
 import com.mx.models.ondemand.mixins.MixinDefinition;
+import com.mx.models.ondemand.mixins.OnDemandAccountsXmlMixin;
 import com.mx.models.ondemand.mixins.SessionXmlMixin;
 import com.mx.models.ondemand.mixins.TransactionMixIn;
 import com.mx.models.ondemand.mixins.TransactionsPageMixin;
@@ -265,6 +267,10 @@ public class Resources {
     module.addSerializer(AccountOwner.class, new MdxOnDemandSerializer<>(
         new MixinDefinition(AccountOwner.class, AccountOwnerXmlMixin.class),
         new MixinDefinition(AccountOwnerDetails.class, AccountOwnerDetailsXmlMixin.class)));
+
+    module.addSerializer(OnDemandAccounts.class, new MdxOnDemandSerializer<>(
+        new MixinDefinition(OnDemandAccounts.class, OnDemandAccountsXmlMixin.class),
+        new MixinDefinition(Account.class, AccountXmlMixin.class)));
   }
 
   private static void registerProfileModelClasses(GsonBuilder builder) {

--- a/mdx-models/src/main/java/com/mx/models/account/OnDemandAccounts.java
+++ b/mdx-models/src/main/java/com/mx/models/account/OnDemandAccounts.java
@@ -1,0 +1,26 @@
+package com.mx.models.account;
+
+import com.mx.models.MdxBase;
+import com.mx.models.MdxList;
+
+/**
+ * Represents a list of accounts. Helps for OnDemand serialization
+ */
+public class OnDemandAccounts extends MdxBase<OnDemandAccounts> {
+  private MdxList<Account> accounts;
+
+  public OnDemandAccounts() {
+  }
+
+  public OnDemandAccounts(MdxList<Account> accounts) {
+    this.accounts = accounts;
+  }
+
+  public final void setAccounts(MdxList<Account> accounts) {
+    this.accounts = accounts;
+  }
+
+  public final MdxList<Account> getAccounts() {
+    return accounts;
+  }
+}

--- a/mdx-models/src/main/java/com/mx/models/ondemand/MdxListWrapper.java
+++ b/mdx-models/src/main/java/com/mx/models/ondemand/MdxListWrapper.java
@@ -6,6 +6,7 @@ import com.mx.models.MdxList;
  * We need to have a special class to wrap lists because Jackson will wrap all arrays, regardless of configuration
  * options provided. Lame.
  */
+@Deprecated
 public class MdxListWrapper {
   private final MdxList<?> list;
   private final String wrapperName;

--- a/mdx-models/src/main/java/com/mx/models/ondemand/MdxOnDemandMdxListSerializer.java
+++ b/mdx-models/src/main/java/com/mx/models/ondemand/MdxOnDemandMdxListSerializer.java
@@ -26,6 +26,7 @@ import com.mx.models.ondemand.mixins.XmlSkipInternalAnnotationsIntrospector;
  * Relies on Jackson Mix-ins to control details of serialization. For more information on Jackson Mix-ins see:
  * https://github.com/FasterXML/jackson-docs/wiki/JacksonMixInAnnotations
  */
+@Deprecated
 public class MdxOnDemandMdxListSerializer extends JsonSerializer<MdxListWrapper> {
 
   private final ObjectMapper mapper;

--- a/mdx-models/src/main/java/com/mx/models/ondemand/mixins/OnDemandAccountsXmlMixin.java
+++ b/mdx-models/src/main/java/com/mx/models/ondemand/mixins/OnDemandAccountsXmlMixin.java
@@ -1,0 +1,18 @@
+package com.mx.models.ondemand.mixins;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonRootName;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
+import com.mx.models.MdxList;
+import com.mx.models.account.Account;
+
+@JsonRootName("accounts")
+public interface OnDemandAccountsXmlMixin {
+  @JacksonXmlElementWrapper(useWrapping = false)
+  @JsonProperty("account")
+  MdxList<Account> getAccounts();
+
+  @JsonIgnore
+  boolean getWrapped();
+}


### PR DESCRIPTION
# Summary of Changes

Adds OnDemandAccounts model with xml mixin. Which allows a list of accounts to be serialized with MdxOnDemandSeralizer. Also deprecates MdxListWrapper and MdxOnDemandListSerializer since this causes an exception on empty lists

Fixes # (issue)

Fixes this exception for empty lists: `org.springframework.web.util.NestedServletException: Request processing failed; nested exception is org.springframework.http.converter.HttpMessageNotWritableException: Could not write JSON: Trying to write END_DOCUMENT when document has no root (ie. trying to output empty document).; nested exception is com.fasterxml.jackson.core.JsonGenerationException: Trying to write END_DOCUMENT when document has no root (ie. trying to output empty document).`

## Public API Additions/Changes

Introduces OnDemandAccounts model and associated xml mixin: OnDemandAccountsXmlMixin

## Downstream Consumer Impact

This introduces a new way to serialize a list of accounts. (The old way is still available to use but will cause the above problems) Any lists that need xml serialization should create a specific model and mixin for it

# How Has This Been Tested?

Tested locally for the following cases:

- [x] Get on demand accounts should return a list of accounts
- [x] Get on demand accounts, with a user with no accounts, should not throw an exception and return empty list

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
