### PR TITLE
Add clientDeviceToken field to Authentication

### DIFF
--- a/mdx-models/src/main/java/com/mx/models/id/Authentication.java
+++ b/mdx-models/src/main/java/com/mx/models/id/Authentication.java
@@ -14,6 +14,7 @@ public class Authentication extends MdxBase<Authentication> {
   @Deprecated
   private Boolean canUseRemoteDeposit;
   private List<MfaChallenge> challenges;
+  private String clientDeviceToken;
   private Integer deviceHeight;
   private String deviceId;
   private Boolean deviceIsJailbroken;
@@ -73,6 +74,14 @@ public class Authentication extends MdxBase<Authentication> {
 
   public final void setChallenges(List<MfaChallenge> newChallenges) {
     this.challenges = newChallenges;
+  }
+
+  public final String getClientDeviceToken() {
+    return clientDeviceToken;
+  }
+
+  public final void setClientDeviceToken(String clientDeviceToken) {
+    this.clientDeviceToken = clientDeviceToken;
   }
 
   public final Integer getDeviceHeight() {


### PR DESCRIPTION
# Summary of Changes

- Adding a new field to Authentication: clientDeviceToken
- This is meant to be used for a device token generated by the client

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
