### PR TITLE
test: adding a unit test for GatewayEventBus

### DIFF
--- a/mdx-gateway-generator/gradle.lockfile
+++ b/mdx-gateway-generator/gradle.lockfile
@@ -1,7 +1,7 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.auth0:java-jwt:4.1.0=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+com.auth0:java-jwt:4.2.1=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 com.fasterxml.jackson.core:jackson-annotations:2.14.0-rc1=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 com.fasterxml.jackson.core:jackson-core:2.14.0-rc1=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 com.fasterxml.jackson.core:jackson-databind:2.14.0-rc1=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
@@ -9,12 +9,12 @@ com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.14.0-rc1=compileClassp
 com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.14.0-rc1=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 com.fasterxml.jackson:jackson-bom:2.14.0-rc1=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 com.fasterxml.woodstox:woodstox-core:6.3.1=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-com.github.mxenabled.path-sdk:common:1.0.2=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-com.github.mxenabled.path-sdk:context:1.0.2=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-com.github.mxenabled.path-sdk:gateway-generator:1.0.2=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-com.github.mxenabled.path-sdk:gateway:1.0.2=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-com.github.mxenabled.path-sdk:messaging:1.0.2=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-com.github.mxenabled.path-sdk:utilities:1.0.2=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+com.github.mxenabled.path-sdk:common:1.1.1=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+com.github.mxenabled.path-sdk:context:1.1.1=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+com.github.mxenabled.path-sdk:gateway-generator:1.1.1=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+com.github.mxenabled.path-sdk:gateway:1.1.1=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+com.github.mxenabled.path-sdk:messaging:1.1.1=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+com.github.mxenabled.path-sdk:utilities:1.1.1=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 com.github.spotbugs:spotbugs-annotations:4.7.2=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 com.google.auto.service:auto-service-annotations:1.0.1=runtimeClasspath,testRuntimeClasspath
 com.google.auto.service:auto-service:1.0.1=runtimeClasspath,testRuntimeClasspath

--- a/mdx-gateways/gradle.lockfile
+++ b/mdx-gateways/gradle.lockfile
@@ -2,7 +2,7 @@
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
 antlr:antlr:2.7.7=checkstyle
-com.auth0:java-jwt:4.1.0=annotationProcessor,compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+com.auth0:java-jwt:4.2.1=annotationProcessor,compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 com.beust:jcommander:1.48=pmd
 com.fasterxml.jackson.core:jackson-annotations:2.14.0-rc1=annotationProcessor,compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 com.fasterxml.jackson.core:jackson-core:2.14.0-rc1=annotationProcessor,compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
@@ -11,12 +11,12 @@ com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.14.0-rc1=annotationPro
 com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.14.0-rc1=annotationProcessor,compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 com.fasterxml.jackson:jackson-bom:2.14.0-rc1=annotationProcessor,compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 com.fasterxml.woodstox:woodstox-core:6.3.1=annotationProcessor,compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-com.github.mxenabled.path-sdk:common:1.0.2=annotationProcessor,compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-com.github.mxenabled.path-sdk:context:1.0.2=annotationProcessor,compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-com.github.mxenabled.path-sdk:gateway-generator:1.0.2=annotationProcessor
-com.github.mxenabled.path-sdk:gateway:1.0.2=annotationProcessor,compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-com.github.mxenabled.path-sdk:messaging:1.0.2=annotationProcessor,compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-com.github.mxenabled.path-sdk:utilities:1.0.2=annotationProcessor,compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+com.github.mxenabled.path-sdk:common:1.1.1=annotationProcessor,compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+com.github.mxenabled.path-sdk:context:1.1.1=annotationProcessor,compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+com.github.mxenabled.path-sdk:gateway-generator:1.1.1=annotationProcessor
+com.github.mxenabled.path-sdk:gateway:1.1.1=annotationProcessor,compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+com.github.mxenabled.path-sdk:messaging:1.1.1=annotationProcessor,compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+com.github.mxenabled.path-sdk:utilities:1.1.1=annotationProcessor,compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 com.github.spotbugs:spotbugs-annotations:4.4.2=spotbugs
 com.github.spotbugs:spotbugs-annotations:4.7.2=annotationProcessor,compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 com.github.spotbugs:spotbugs:4.4.2=spotbugs

--- a/mdx-gateways/src/test/groovy/com/mx/path/gateway/GatewayConfiguratorTest.groovy
+++ b/mdx-gateways/src/test/groovy/com/mx/path/gateway/GatewayConfiguratorTest.groovy
@@ -10,6 +10,7 @@ import com.mx.path.gateway.api.id.IdGateway
 import com.mx.path.gateway.behavior.GatewayBehavior
 import com.mx.path.gateway.configuration.AccessorProxy
 import com.mx.path.gateway.configuration.AccessorProxyMap
+import com.mx.path.gateway.events.GatewayEventBus
 import com.mx.path.gateway.remote.account.RemoteAccountGateway
 import com.mx.path.gateway.remote.account.RemoteTransactionGateway
 import com.mx.path.model.context.facility.Facilities
@@ -192,6 +193,7 @@ class GatewayConfiguratorTest extends Specification {
     assert Facilities.getEncryptionService("clientName").class == EncryptionServiceImpl.class
     assert Facilities.getMessageBroker("clientName").class == MessageBrokerImpl.class
     assert Facilities.getFaultTolerantExecutor("clientName").class == FaultTolerantExecutorImpl.class
+    assert Facilities.getEventBus("clientName").class == GatewayEventBus.class
     assert ((StoreImpl) Facilities.getCacheStore("clientName")).getConfigurations().get("key1") == "value1"
     assert ((StoreImpl) Facilities.getSessionStore("clientName")).getConfigurations().get("key1") == "value2"
     assert ((EncryptionServiceImpl) Facilities.getEncryptionService("clientName")).getConfigurations().get("key1") == "value3"

--- a/mdx-models/gradle.lockfile
+++ b/mdx-models/gradle.lockfile
@@ -2,7 +2,7 @@
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
 antlr:antlr:2.7.7=checkstyle
-com.auth0:java-jwt:4.1.0=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+com.auth0:java-jwt:4.2.1=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 com.beust:jcommander:1.48=pmd
 com.fasterxml.jackson.core:jackson-annotations:2.14.0-rc1=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 com.fasterxml.jackson.core:jackson-core:2.14.0-rc1=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
@@ -11,11 +11,11 @@ com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.14.0-rc1=compileClassp
 com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.14.0-rc1=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 com.fasterxml.jackson:jackson-bom:2.14.0-rc1=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 com.fasterxml.woodstox:woodstox-core:6.3.1=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-com.github.mxenabled.path-sdk:common:1.0.2=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-com.github.mxenabled.path-sdk:context:1.0.2=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-com.github.mxenabled.path-sdk:gateway:1.0.2=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-com.github.mxenabled.path-sdk:messaging:1.0.2=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-com.github.mxenabled.path-sdk:utilities:1.0.2=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+com.github.mxenabled.path-sdk:common:1.1.1=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+com.github.mxenabled.path-sdk:context:1.1.1=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+com.github.mxenabled.path-sdk:gateway:1.1.1=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+com.github.mxenabled.path-sdk:messaging:1.1.1=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+com.github.mxenabled.path-sdk:utilities:1.1.1=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 com.github.spotbugs:spotbugs-annotations:4.4.2=spotbugs
 com.github.spotbugs:spotbugs-annotations:4.7.2=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 com.github.spotbugs:spotbugs:4.4.2=spotbugs

--- a/mdx-models/src/main/java/com/mx/models/account/Account.java
+++ b/mdx-models/src/main/java/com/mx/models/account/Account.java
@@ -93,6 +93,8 @@ public class Account extends MdxBase<Account> {
   private LocalDate startedOn;
   @XmlElement(name = "statement_balance")
   private BigDecimal statementBalance;
+  @XmlElement(name = "statement_closed_on")
+  private String statementClosedOn;
   @XmlElement(name = "subtype")
   private String subtype;
   @XmlElement(name = "type")
@@ -450,6 +452,14 @@ public class Account extends MdxBase<Account> {
 
   public final void setStatementBalance(BigDecimal newStatementBalance) {
     this.statementBalance = newStatementBalance;
+  }
+
+  public final String getStatementClosedOn() {
+    return statementClosedOn;
+  }
+
+  public final void setStatementClosedOn(String newStatementClosedOn) {
+    this.statementClosedOn = newStatementClosedOn;
   }
 
   public final String getSubtype() {

--- a/realtime/gradle.lockfile
+++ b/realtime/gradle.lockfile
@@ -2,7 +2,7 @@
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
 antlr:antlr:2.7.7=checkstyle
-com.auth0:java-jwt:4.1.0=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+com.auth0:java-jwt:4.2.1=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 com.beust:jcommander:1.48=pmd
 com.fasterxml.jackson.core:jackson-annotations:2.14.0-rc1=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 com.fasterxml.jackson.core:jackson-core:2.14.0-rc1=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
@@ -11,11 +11,11 @@ com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.14.0-rc1=compileClassp
 com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.14.0-rc1=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 com.fasterxml.jackson:jackson-bom:2.14.0-rc1=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 com.fasterxml.woodstox:woodstox-core:6.3.1=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-com.github.mxenabled.path-sdk:common:1.0.2=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-com.github.mxenabled.path-sdk:context:1.0.2=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-com.github.mxenabled.path-sdk:gateway:1.0.2=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-com.github.mxenabled.path-sdk:messaging:1.0.2=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
-com.github.mxenabled.path-sdk:utilities:1.0.2=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+com.github.mxenabled.path-sdk:common:1.1.1=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+com.github.mxenabled.path-sdk:context:1.1.1=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+com.github.mxenabled.path-sdk:gateway:1.1.1=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+com.github.mxenabled.path-sdk:messaging:1.1.1=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
+com.github.mxenabled.path-sdk:utilities:1.1.1=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 com.github.spotbugs:spotbugs-annotations:4.4.2=spotbugs
 com.github.spotbugs:spotbugs-annotations:4.7.2=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 com.github.spotbugs:spotbugs:4.4.2=spotbugs


### PR DESCRIPTION
# Summary of Changes

This updates to SDK 1.1.1 and adds a unit test to ensure a GatewayEventBus facility is added even when not specified in the configuration yaml.

Fixes https://gitlab.mx.com/mx/money-experiences/path/path-issues/-/issues/1014

Also:
Adding missing statement_closed_on to Account per https://developer.mx.com/mdx/v5/#mdx-data-models-account-fields

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
