### PR TITLE
fix: make statement_closed_on LocalDate

### DIFF
--- a/mdx-models/src/main/java/com/mx/models/account/Account.java
+++ b/mdx-models/src/main/java/com/mx/models/account/Account.java
@@ -94,7 +94,7 @@ public class Account extends MdxBase<Account> {
   @XmlElement(name = "statement_balance")
   private BigDecimal statementBalance;
   @XmlElement(name = "statement_closed_on")
-  private String statementClosedOn;
+  private LocalDate statementClosedOn;
   @XmlElement(name = "subtype")
   private String subtype;
   @XmlElement(name = "type")
@@ -454,11 +454,11 @@ public class Account extends MdxBase<Account> {
     this.statementBalance = newStatementBalance;
   }
 
-  public final String getStatementClosedOn() {
+  public final LocalDate getStatementClosedOn() {
     return statementClosedOn;
   }
 
-  public final void setStatementClosedOn(String newStatementClosedOn) {
+  public final void setStatementClosedOn(LocalDate newStatementClosedOn) {
     this.statementClosedOn = newStatementClosedOn;
   }
 


### PR DESCRIPTION
# Summary of Changes

Make newly added statement_closed_on LocalDate instead of String per established pattern for date fields

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
