### PR TITLE
fix: added serialization for fromAccountId and toAccountId

### DIFF
--- a/mdx-models/src/main/java/com/mx/models/transfer/options/FeeListOptions.java
+++ b/mdx-models/src/main/java/com/mx/models/transfer/options/FeeListOptions.java
@@ -2,9 +2,13 @@ package com.mx.models.transfer.options;
 
 import lombok.Data;
 
+import com.google.gson.annotations.SerializedName;
+
 @Data
 public class FeeListOptions {
   private Number amount;
+  @SerializedName("from_account_id")
   private String fromAccountId;
+  @SerializedName("to_account_id")
   private String toAccountId;
 }


### PR DESCRIPTION
# Summary of Changes

Related to: 
- https://gitlab.mx.com/mx/money-experiences/helios/helios-issues/-/issues/11236
- https://gitlab.mx.com/mx/money-experiences/path/path-issues/-/issues/928

Jesse Stanciu from front-end mobile was unable to connect to the transfer/fees endpoint. Upon looking into it, I discovered that our models are not currently serializing the fields from_account_id and to_account_id from camelcase to snakecase. 

It seems that when this was originally written, the test instructions also mistakenly had the query parameters set to camelcase (https://sabotage.internal.mx/release/view/33872). This MR is that fix in path-mdx-models.

Fixes # (issue)
- https://gitlab.mx.com/mx/money-experiences/path/path-issues/-/issues/1246

## Public API Additions/Changes

fromAccountId and toAccountId in FeeListOptions are now being serialized to snakecase

## Downstream Consumer Impact

Cash Advance and other new features using FeeListOptions should work properly now

# How Has This Been Tested?

- [x] Performed local tests to verify that query parameters were not serialized correctly.

example CURL: 
curl --location --request GET 'http://localhost:3003/afcu/users/U-ebf4d99099fc5f0b/transfers/fees?amount=0.01&fromAccountId=324C9EE0434DEB9F2AC51154574D884879D11286588E2064' \
--header 'Accept: application/vnd.mx.mdx.v6+json' \
--header 'MX-SESSION-KEY: a0a681bf-e846-49c9-bb65-2ba4d4849b88' \
--header 'Content-Type: application/vnd.mx.mdx.v6+json' \
--header 'Accept-Encoding: gzip;q=0'

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
