### PR TITLE
Use session.current to get user id in UserIdProvider

### DIFF
--- a/mdx-models/src/main/java/com/mx/models/UserIdProvider.java
+++ b/mdx-models/src/main/java/com/mx/models/UserIdProvider.java
@@ -3,33 +3,26 @@ package com.mx.models;
 import java.util.function.Supplier;
 
 import com.mx.common.models.MdxBase;
+import com.mx.path.model.context.Session;
 
 /**
  * User ID Provider
  *
- * This static class contains a user id supplier that can be provided by application.
+ * This static class uses the current session to the current user's id and put it on provided objects.
  * This provider is called in the constructor of Mdx Models that need a user id.
- *
- * Example:
- * <pre>
- * UserIdProvider.setUserIdProvider(() -> {
- *   if (Session.current() != null) {
- *     return Session.current().getUserId();
- *   }
- *   return null;
- * });
- * </pre>
  */
 public class UserIdProvider {
-  private static Supplier<String> userIdProvider = null;
-
   public static void setUserId(MdxBase<?> obj) {
-    if (userIdProvider != null) {
-      obj.setUserId(userIdProvider.get());
+    if (Session.current() != null) {
+      obj.setUserId(Session.current().getUserId());
     }
   }
 
+  /**
+   * @deprecated This no longer any affect. Now uses Session.current()
+   * todo: V2 - remove
+   */
+  @Deprecated
   public static void setUserIdProvider(Supplier<String> newUserIdProvider) {
-    userIdProvider = newUserIdProvider;
   }
 }

--- a/mdx-models/src/test/groovy/com/mx/models/UserIdProviderTest.groovy
+++ b/mdx-models/src/test/groovy/com/mx/models/UserIdProviderTest.groovy
@@ -1,0 +1,27 @@
+package com.mx.models
+
+import com.mx.models.account.Account
+import com.mx.path.model.context.Session
+
+import spock.lang.Specification
+
+class UserIdProviderTest extends Specification {
+  void cleanup() {
+    Session.clearSession()
+  }
+
+  def "SetUserId"() {
+    given:
+    Session.createSession()
+    Session.current().setUserId("user1234")
+
+    def account = new Account()
+
+    when:
+    UserIdProvider.setUserIdProvider(null)
+    UserIdProvider.setUserId(account)
+
+    then:
+    account.getUserId() == "user1234"
+  }
+}


### PR DESCRIPTION
# Summary of Changes

* use session.current to get user id in UserIdProvider
* mark UserIdProvider.setUserIdProvider deprecated

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
