### PR TITLE
refactor: move serialization components from mdx-web

### DIFF
--- a/mdx-web/build.gradle
+++ b/mdx-web/build.gradle
@@ -1,6 +1,6 @@
 coppuccino {
   coverage {
-    minimumCoverage = 0.63
+    minimumCoverage = 0.67
   }
 }
 

--- a/mdx-web/src/main/java/com/mx/path/model/mdx/web/MdxOnDemandSerializationWebMvcConfigurer.java
+++ b/mdx-web/src/main/java/com/mx/path/model/mdx/web/MdxOnDemandSerializationWebMvcConfigurer.java
@@ -1,0 +1,52 @@
+package com.mx.path.model.mdx.web;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.mx.models.Resources;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.converter.StringHttpMessageConverter;
+import org.springframework.http.converter.json.GsonHttpMessageConverter;
+import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
+import org.springframework.http.converter.xml.MappingJackson2XmlHttpMessageConverter;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class MdxOnDemandSerializationWebMvcConfigurer implements WebMvcConfigurer {
+  /**
+   * List of all configured converts. All others will be removed before inserting custom MappingJackson2XmlHttpMessageConverter
+   */
+  static final List<Class<?>> CONVERT_CLASSES;
+  static {
+    CONVERT_CLASSES = new ArrayList<>();
+    CONVERT_CLASSES.add(GsonHttpMessageConverter.class);
+    CONVERT_CLASSES.add(StringHttpMessageConverter.class);
+  }
+
+  @Override
+  public final void configureMessageConverters(List<HttpMessageConverter<?>> converters) {
+
+    // Get rid of unused converters
+    // These get in the way of the other
+    List<HttpMessageConverter<?>> toRemove = converters.stream().filter(t -> !CONVERT_CLASSES.contains(t.getClass())).collect(Collectors.toCollection(ArrayList::new));
+    converters.removeAll(toRemove);
+
+    // XML
+    converters.add(new MappingJackson2XmlHttpMessageConverter(Jackson2ObjectMapperBuilder
+        .xml()
+        .modules(payloadModule())
+        .build()));
+  }
+
+  public final SimpleModule payloadModule() {
+    SimpleModule module = new SimpleModule();
+
+    Resources.registerOnDemandResources(module);
+
+    return module;
+  }
+}

--- a/mdx-web/src/main/java/com/mx/path/model/mdx/web/MdxSerializationConfiguration.java
+++ b/mdx-web/src/main/java/com/mx/path/model/mdx/web/MdxSerializationConfiguration.java
@@ -1,0 +1,21 @@
+package com.mx.path.model.mdx.web;
+
+import com.google.gson.Gson;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@SuppressWarnings("checkstyle:designforextension")
+public class MdxSerializationConfiguration {
+  @Bean(name = "gson")
+  public MdxSerializerFactoryBean gsonBeanFactory() {
+    MdxSerializerFactoryBean factory = new MdxSerializerFactoryBean();
+    return factory;
+  }
+
+  @Bean
+  public Gson gson() throws Exception {
+    return gsonBeanFactory().getObject();
+  }
+}

--- a/mdx-web/src/main/java/com/mx/path/model/mdx/web/MdxSerializerFactoryBean.java
+++ b/mdx-web/src/main/java/com/mx/path/model/mdx/web/MdxSerializerFactoryBean.java
@@ -1,0 +1,33 @@
+package com.mx.path.model.mdx.web;
+
+import com.google.gson.FieldNamingPolicy;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.mx.models.Resources;
+
+import org.springframework.beans.factory.FactoryBean;
+
+public class MdxSerializerFactoryBean implements FactoryBean<Gson> {
+  public MdxSerializerFactoryBean() {
+  }
+
+  @Override
+  public final Gson getObject() throws Exception {
+    GsonBuilder baseGson = new GsonBuilder().setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
+        .setDateFormat("YYYY-MM-dd").setPrettyPrinting();
+
+    Resources.registerResources(baseGson);
+
+    return baseGson.create();
+  }
+
+  @Override
+  public final Class<?> getObjectType() {
+    return Gson.class;
+  }
+
+  @Override
+  public final boolean isSingleton() {
+    return false;
+  }
+}

--- a/mdx-web/src/main/java/com/mx/path/model/mdx/web/TracingProviderComponent.java
+++ b/mdx-web/src/main/java/com/mx/path/model/mdx/web/TracingProviderComponent.java
@@ -1,0 +1,19 @@
+package com.mx.path.model.mdx.web;
+
+import com.mx.path.model.context.tracing.CustomTracer;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import io.opentracing.Tracer;
+
+/**
+ * Spring component that sets the tracing context in CustomTracer.
+ */
+@Component
+public class TracingProviderComponent {
+  @Autowired
+  public final void provideTracer(Tracer tracer) {
+    CustomTracer.setTracer(tracer);
+  }
+}

--- a/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/MdxSerializerFactoryBeanTest.groovy
+++ b/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/MdxSerializerFactoryBeanTest.groovy
@@ -1,0 +1,21 @@
+package com.mx.path.model.mdx.web;
+
+import spock.lang.Specification
+
+class MdxSerializerFactoryBeanTest extends Specification {
+  MdxSerializerFactoryBean subject
+
+  def setup() {
+    subject = new MdxSerializerFactoryBean()
+  }
+
+  def "testGetsGsonSerializer"() {
+    expect:
+    subject.getObject() != null
+  }
+
+  def "testIsNotSingleton"() {
+    expect:
+    !subject.isSingleton()
+  }
+}

--- a/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/MdxSerializerTest.groovy
+++ b/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/MdxSerializerTest.groovy
@@ -1,0 +1,37 @@
+package com.mx.path.model.mdx.web
+
+import com.google.gson.Gson
+import com.mx.models.id.Authentication
+
+import spock.lang.Specification
+
+class MdxSerializerTest extends Specification {
+
+  Gson subject
+  def json = "{`authentication`:{`login`: `bob`,`password`: `Pa\$\$w0rd`}}".replace("`", "\"")
+  def password = "Pa\$\$w0rd"
+
+  def setup() {
+    subject = new MdxSerializerFactoryBean().getObject()
+  }
+
+  def "testDeserializesAuthentication"() {
+    given:
+    Authentication result = subject.fromJson(json, Authentication.class)
+
+    expect:
+    "bob" == result.getLogin()
+    password.toCharArray() == result.getPassword()
+  }
+
+  def "testSerializesAuthentication"() {
+    given:
+    def expected = "{`login`: `bob`,`password`: `Pa\$\$w0rd`}".replace("`", "\"")
+    def auth = new Authentication()
+    auth.setLogin("bob")
+    auth.setPassword(password.toCharArray())
+
+    expect:
+    subject.toJson(auth).replace("\n", "").replace("  ", "") == expected
+  }
+}


### PR DESCRIPTION
# Summary of Changes

Moves Spring components that setup MDX serialization from mdx-web to mdx-model:mdx-web.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
