### PR TITLE
refactor: remove spring-loaded exception reporter

### DIFF
--- a/mdx-web/src/main/java/com/mx/path/model/mdx/web/filter/ErrorHandler.java
+++ b/mdx-web/src/main/java/com/mx/path/model/mdx/web/filter/ErrorHandler.java
@@ -32,9 +32,6 @@ class ErrorHandler {
   @Autowired
   private Environment environment;
 
-  @Autowired
-  private ExceptionReporter springExceptionReporter;
-
   // Private
 
   private JsonObject exceptionToJson(PathRequestException ex) {
@@ -120,14 +117,10 @@ class ErrorHandler {
       context.setSessionCreateTime(Session.current().getStartedAt().toEpochSecond(ZoneOffset.UTC));
       context.getContext().put("client_id", RequestContext.current().getClientId());
     }
-    exceptionReporter().report(ex, ex.getMessage(), context);
-  }
 
-  private ExceptionReporter exceptionReporter() {
-    if (Facilities.getExceptionReporter(RequestContext.current().getClientId()) != null) {
-      return Facilities.getExceptionReporter(RequestContext.current().getClientId());
+    ExceptionReporter exceptionReporter = Facilities.getExceptionReporter(RequestContext.current().getClientId());
+    if (exceptionReporter != null) {
+      exceptionReporter.report(ex, ex.getMessage(), context);
     }
-
-    return springExceptionReporter;
   }
 }


### PR DESCRIPTION
The Spring ExceptionReporter was removed from facilities and the autowiree will fail if one is not present.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
