### PR TITLE
Feat: Add pending function to TransactionsBaseAccessor and pending en…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
   id "idea"
   id "com.github.mxenabled.vogue" version "1.0.2"
-  id "com.github.mxenabled.coppuccino" version "3.2.1" apply false
+  id "com.github.mxenabled.coppuccino" version "3.2.9" apply false
   id "io.freefair.lombok" version "6.5.1" apply false
   id "io.github.gradle-nexus.publish-plugin" version "1.1.0"
 }

--- a/mdx-models/src/main/java/com/mx/accessors/account/TransactionBaseAccessor.java
+++ b/mdx-models/src/main/java/com/mx/accessors/account/TransactionBaseAccessor.java
@@ -99,6 +99,17 @@ public abstract class TransactionBaseAccessor extends Accessor {
   }
 
   /**
+   * List pending transactions for an account
+   * @param accountId
+   * @return
+   */
+  @GatewayAPI
+  @API(description = "List pending transactions")
+  public AccessorResponse<MdxList<Transaction>> pending(String accountId) {
+    throw new AccessorMethodNotImplementedException();
+  }
+
+  /**
    * Search paged transactions
    * @param searchRequest
    * @return

--- a/mdx-web/src/main/java/com/mx/web/mdx/controllers/AccountsController.java
+++ b/mdx-web/src/main/java/com/mx/web/mdx/controllers/AccountsController.java
@@ -91,6 +91,12 @@ public class AccountsController extends BaseController {
     return new ResponseEntity<>(response.getResult().wrapped(), createMultiMapForResponse(response.getHeaders()), HttpStatus.OK);
   }
 
+  @RequestMapping(value = "/users/{userId}/accounts/{id}/transactions/pending", method = RequestMethod.GET)
+  public final ResponseEntity<MdxList<Transaction>> pendingTransactions(@PathVariable("id") String accountId) throws Exception {
+    AccessorResponse<MdxList<Transaction>> response = gateway().accounts().transactions().pending(accountId);
+    return new ResponseEntity<>(response.getResult().wrapped(), createMultiMapForResponse(response.getHeaders()), HttpStatus.OK);
+  }
+
   @RequestMapping(value = "/users/{userId}/accounts/{id}/transactions/recent", method = RequestMethod.GET)
   public final ResponseEntity<MdxList<Transaction>> recentTransactions(@PathVariable("id") String accountId) throws Exception {
     AccessorResponse<MdxList<Transaction>> response = gateway().accounts().transactions().recent(accountId);

--- a/mdx-web/src/test/groovy/com/mx/web/controllers/AccountsControllerTest.groovy
+++ b/mdx-web/src/test/groovy/com/mx/web/controllers/AccountsControllerTest.groovy
@@ -158,6 +158,20 @@ class AccountsControllerTest extends Specification implements WithMockery {
     result.body == transactions
   }
 
+  def "pending transactions"() {
+    given:
+    AccountsController.setGateway(gateway)
+    MdxList<Transaction> transactions = new MdxList<Transaction>()
+
+    when:
+    Mockito.doReturn(new AccessorResponse<MdxList<Transaction>>().withResult(transactions)).when(transactionGateway).pending("A-123")
+    def result = subject.pendingTransactions("A-123")
+
+    then:
+    verify(transactionGateway).pending("A-123") || true
+    result.body == transactions
+  }
+
   def "list transactions"() {
     given:
 


### PR DESCRIPTION
# Summary of Changes

Adds Pending Transactions controller endpoint and TransferBaseAccessor function `pending()` to v1 (master)

Fixes # https://gitlab.mx.com/mx/experiences/alaska-usa/alaska-usa-issues/-/issues/107

## Public API Additions/Changes

Newly added endpoint is `GET /users/{user_id}/accounts/{id}/transactions/pending`

## Downstream Consumer Impact

No impact as this endpoint is new and has not been implemented for any clients

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation https://gitlab.mx.com/mx/gutenberg/-/merge_requests/711
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
