### PR TITLE
feat: add before initialization hook to SpringMdxGatewayManagerTest

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
   id "io.github.gradle-nexus.publish-plugin" version "1.1.0"
 }
 
-version "2.1.0" // x-release-please-version
+version "2.1.0-SNAPSHOT" // x-release-please-version
 
 def platformProject = "platform"
 def publishedProjects = [

--- a/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/SpringMdxGatewayManagerTest.groovy
+++ b/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/SpringMdxGatewayManagerTest.groovy
@@ -232,6 +232,19 @@ class SpringMdxGatewayManagerTest extends Specification implements WithMockery {
     called
   }
 
+  def "executes before initialization hook"() {
+    when:
+    def called = false
+    SpringMdxGatewayManager.registerBeforeInitialization({ Configurator<Gateway> configurator ->
+      called = true
+    })
+    withYaml()
+    makeGateway("development")
+
+    then:
+    called
+  }
+
   def makeGateway(profiles, clientId = "afcu") {
     new SpringMdxGatewayManager().setActiveProfiles(profiles)
     return SpringMdxGatewayManager.getClientGateway(clientId)


### PR DESCRIPTION
Add a callback that will fire after Spring initialization and before GatewayConfigurator does its thing.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
