### PR TITLE
fix: Add account model relation to cross account transfers

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
   id "idea"
-  id "com.github.mxenabled.vogue" version "1.0.2"
-  id "com.github.mxenabled.coppuccino" version "3.2.9" apply false
+  id "com.github.mxenabled.vogue" version "1.0.3"
+  id "com.github.mxenabled.coppuccino" version "3.2.10" apply false
   id "io.freefair.lombok" version "6.5.1" apply false
   id "io.github.gradle-nexus.publish-plugin" version "1.1.0"
 }

--- a/mdx-models/src/main/java/com/mx/path/model/mdx/model/cross_account_transfer/CrossAccountRecurringTransfer.java
+++ b/mdx-models/src/main/java/com/mx/path/model/mdx/model/cross_account_transfer/CrossAccountRecurringTransfer.java
@@ -2,9 +2,17 @@ package com.mx.path.model.mdx.model.cross_account_transfer;
 
 import java.time.LocalDate;
 
-import com.mx.common.models.MdxBase;
-import com.mx.path.model.mdx.model.UserIdProvider;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
 
+import com.mx.common.models.MdxBase;
+import com.mx.path.model.mdx.model.MdxRelationId;
+import com.mx.path.model.mdx.model.UserIdProvider;
+import com.mx.path.model.mdx.model.account.Account;
+
+@EqualsAndHashCode(callSuper = true)
+@Data
 public class CrossAccountRecurringTransfer extends MdxBase<CrossAccountRecurringTransfer> {
   private String accountTypeId;
   private Integer accountTypeNumber;
@@ -14,6 +22,7 @@ public class CrossAccountRecurringTransfer extends MdxBase<CrossAccountRecurring
   private Integer endAfterAmount;
   private Integer endAfterCount;
   private LocalDate endOn;
+  @Getter(onMethod_ = { @MdxRelationId(referredClass = Account.class) })
   private String fromAccountId;
   private String frequencyId;
   private String id;
@@ -25,133 +34,5 @@ public class CrossAccountRecurringTransfer extends MdxBase<CrossAccountRecurring
 
   public CrossAccountRecurringTransfer() {
     UserIdProvider.setUserId(this);
-  }
-
-  public final String getAccountTypeId() {
-    return accountTypeId;
-  }
-
-  public final void setAccountTypeId(String accountTypeId) {
-    this.accountTypeId = accountTypeId;
-  }
-
-  public final Integer getAccountTypeNumber() {
-    return accountTypeNumber;
-  }
-
-  public final void setAccountTypeNumber(Integer accountTypeNumber) {
-    this.accountTypeNumber = accountTypeNumber;
-  }
-
-  public final Double getAmount() {
-    return amount;
-  }
-
-  public final void setAmount(Double amount) {
-    this.amount = amount;
-  }
-
-  public final String getConfirmationId() {
-    return confirmationId;
-  }
-
-  public final void setConfirmationId(String confirmationId) {
-    this.confirmationId = confirmationId;
-  }
-
-  public final String getDestinationId() {
-    return destinationId;
-  }
-
-  public final void setDestinationId(String destinationId) {
-    this.destinationId = destinationId;
-  }
-
-  public final Integer getEndAfterAmount() {
-    return endAfterAmount;
-  }
-
-  public final void setEndAfterAmount(Integer endAfterAmount) {
-    this.endAfterAmount = endAfterAmount;
-  }
-
-  public final Integer getEndAfterCount() {
-    return endAfterCount;
-  }
-
-  public final void setEndAfterCount(Integer endAfterCount) {
-    this.endAfterCount = endAfterCount;
-  }
-
-  public final LocalDate getEndOn() {
-    return endOn;
-  }
-
-  public final void setEndOn(LocalDate endOn) {
-    this.endOn = endOn;
-  }
-
-  public final String getFromAccountId() {
-    return fromAccountId;
-  }
-
-  public final void setFromAccountId(String fromAccountId) {
-    this.fromAccountId = fromAccountId;
-  }
-
-  public final String getFrequencyId() {
-    return frequencyId;
-  }
-
-  public final void setFrequencyId(String frequencyId) {
-    this.frequencyId = frequencyId;
-  }
-
-  public final String getId() {
-    return id;
-  }
-
-  public final void setId(String id) {
-    this.id = id;
-  }
-
-  public final LocalDate getLastTransferOn() {
-    return lastTransferOn;
-  }
-
-  public final void setLastTransferOn(LocalDate lastTransferOn) {
-    this.lastTransferOn = lastTransferOn;
-  }
-
-  public final String getMemo() {
-    return memo;
-  }
-
-  public final void setMemo(String memo) {
-    this.memo = memo;
-  }
-
-  public final LocalDate getNextTransferOn() {
-    return nextTransferOn;
-  }
-
-  public final void setNextTransferOn(LocalDate nextTransferOn) {
-    this.nextTransferOn = nextTransferOn;
-  }
-
-  public final String getStatus() {
-    return status;
-  }
-
-  public final void setStatus(String status) {
-    this.status = status;
-  }
-
-  public final LocalDate getStartOn() {
-    return startOn;
-  }
-
-  public final void setStartOn(LocalDate startOn) {
-    this.startOn = startOn;
   }
 }

--- a/mdx-models/src/main/java/com/mx/path/model/mdx/model/cross_account_transfer/CrossAccountTransfer.java
+++ b/mdx-models/src/main/java/com/mx/path/model/mdx/model/cross_account_transfer/CrossAccountTransfer.java
@@ -2,9 +2,17 @@ package com.mx.path.model.mdx.model.cross_account_transfer;
 
 import java.time.LocalDate;
 
-import com.mx.common.models.MdxBase;
-import com.mx.path.model.mdx.model.UserIdProvider;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
 
+import com.mx.common.models.MdxBase;
+import com.mx.path.model.mdx.model.MdxRelationId;
+import com.mx.path.model.mdx.model.UserIdProvider;
+import com.mx.path.model.mdx.model.account.Account;
+
+@EqualsAndHashCode(callSuper = true)
+@Data
 public final class CrossAccountTransfer extends MdxBase<CrossAccountTransfer> {
   @Deprecated
   private String accountHolder;
@@ -15,6 +23,7 @@ public final class CrossAccountTransfer extends MdxBase<CrossAccountTransfer> {
   private Double amount;
   private String confirmationId;
   private String destinationId;
+  @Getter(onMethod_ = { @MdxRelationId(referredClass = Account.class) })
   private String fromAccountId;
   private String id;
   private String memo;
@@ -27,127 +36,5 @@ public final class CrossAccountTransfer extends MdxBase<CrossAccountTransfer> {
 
   public CrossAccountTransfer() {
     UserIdProvider.setUserId(this);
-  }
-
-  // getter & setters
-
-  public String getAccountHolder() {
-    return accountHolder;
-  }
-
-  public void setAccountHolder(String accountHolder) {
-    this.accountHolder = accountHolder;
-  }
-
-  public String getAccountType() {
-    return accountType;
-  }
-
-  public void setAccountType(String accountType) {
-    this.accountType = accountType;
-  }
-
-  public String getAccountTypeId() {
-    return accountTypeId;
-  }
-
-  public void setAccountTypeId(String accountTypeId) {
-    this.accountTypeId = accountTypeId;
-  }
-
-  public Integer getAccountTypeNumber() {
-    return accountTypeNumber;
-  }
-
-  public void setAccountTypeNumber(Integer accountTypeNumber) {
-    this.accountTypeNumber = accountTypeNumber;
-  }
-
-  public Double getAmount() {
-    return amount;
-  }
-
-  public void setAmount(Double amount) {
-    this.amount = amount;
-  }
-
-  public String getConfirmationId() {
-    return confirmationId;
-  }
-
-  public void setConfirmationId(String confirmationId) {
-    this.confirmationId = confirmationId;
-  }
-
-  public String getDestinationId() {
-    return destinationId;
-  }
-
-  public void setDestinationId(String destinationId) {
-    this.destinationId = destinationId;
-  }
-
-  public String getFromAccountId() {
-    return fromAccountId;
-  }
-
-  public void setFromAccountId(String fromAccountId) {
-    this.fromAccountId = fromAccountId;
-  }
-
-  public String getId() {
-    return id;
-  }
-
-  public void setId(String id) {
-    this.id = id;
-  }
-
-  public String getMemo() {
-    return memo;
-  }
-
-  public void setMemo(String memo) {
-    this.memo = memo;
-  }
-
-  public LocalDate getPostOn() {
-    return postOn;
-  }
-
-  public void setPostOn(LocalDate postOn) {
-    this.postOn = postOn;
-  }
-
-  public LocalDate getPostedOn() {
-    return postedOn;
-  }
-
-  public void setPostedOn(LocalDate postedOn) {
-    this.postedOn = postedOn;
-  }
-
-  public String getRecurringCrossAccountTransferId() {
-    return recurringCrossAccountTransferId;
-  }
-
-  public void setRecurringCrossAccountTransferId(String recurringCrossAccountTransferId) {
-    this.recurringCrossAccountTransferId = recurringCrossAccountTransferId;
-  }
-
-  public String getStatus() {
-    return status;
-  }
-
-  public void setStatus(String status) {
-    this.status = status;
-  }
-
-  public String getToAccountNumber() {
-    return toAccountNumber;
-  }
-
-  public void setToAccountNumber(String toAccountNumber) {
-    this.toAccountNumber = toAccountNumber;
   }
 }


### PR DESCRIPTION
# Summary of Changes

Fixes and issue where the RelationalCacheInvalidationBehavior was not invalidating the cache when a Cross Account Transfer was created.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
