### PR TITLE
fix: remove old term repository from base controller

### DIFF
--- a/mdx-web/src/main/java/com/mx/path/model/mdx/web/controller/BaseController.java
+++ b/mdx-web/src/main/java/com/mx/path/model/mdx/web/controller/BaseController.java
@@ -23,7 +23,7 @@ public class BaseController {
 
   private static ThreadLocal<Gateway> gatewayThreadLocal = new ThreadLocal<>();
 
-  public static void clearRepository() {
+  public static void clearGateway() {
     gatewayThreadLocal.remove();
   }
 

--- a/mdx-web/src/main/java/com/mx/path/model/mdx/web/filter/GatewayFilter.java
+++ b/mdx-web/src/main/java/com/mx/path/model/mdx/web/filter/GatewayFilter.java
@@ -59,7 +59,7 @@ public class GatewayFilter extends OncePerRequestFilter {
     try {
       filterChain.doFilter(request, response);
     } finally {
-      BaseController.clearRepository();
+      BaseController.clearGateway();
     }
   }
 }

--- a/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/AccountNumbersControllerTest.groovy
+++ b/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/AccountNumbersControllerTest.groovy
@@ -31,7 +31,7 @@ class AccountNumbersControllerTest extends Specification {
   }
 
   def cleanup() {
-    AccountsController.clearRepository()
+    AccountsController.clearGateway()
     RequestContext.clear()
   }
 

--- a/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/AccountOwnersControllerTest.groovy
+++ b/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/AccountOwnersControllerTest.groovy
@@ -29,7 +29,7 @@ class AccountOwnersControllerTest extends Specification {
   }
 
   def cleanup() {
-    AccountsController.clearRepository()
+    AccountsController.clearGateway()
     RequestContext.clear()
   }
 

--- a/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/AccountRepaymentsControllerTest.groovy
+++ b/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/AccountRepaymentsControllerTest.groovy
@@ -30,7 +30,7 @@ class AccountRepaymentsControllerTest extends Specification implements WithMocke
   }
 
   def cleanup() {
-    BaseController.clearRepository()
+    BaseController.clearGateway()
   }
 
   def "list repayments interacts with gateway"() {

--- a/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/AccountsControllerTest.groovy
+++ b/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/AccountsControllerTest.groovy
@@ -40,7 +40,7 @@ class AccountsControllerTest extends Specification implements WithMockery {
   }
 
   def cleanup() {
-    AccountsController.clearRepository()
+    AccountsController.clearGateway()
     RequestContext.clear()
   }
 

--- a/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/AchScheduledTransferFrequenciesControllerTest.groovy
+++ b/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/AchScheduledTransferFrequenciesControllerTest.groovy
@@ -38,7 +38,7 @@ class AchScheduledTransferFrequenciesControllerTest extends Specification implem
   }
 
   def cleanup() {
-    BaseController.clearRepository()
+    BaseController.clearGateway()
   }
 
   def "getRecurringTransferFrequencies interacts with gateway"() {

--- a/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/AchScheduledTransfersControllerTest.groovy
+++ b/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/AchScheduledTransfersControllerTest.groovy
@@ -37,7 +37,7 @@ class AchScheduledTransfersControllerTest extends Specification implements WithM
   }
 
   def cleanup() {
-    BaseController.clearRepository()
+    BaseController.clearGateway()
   }
 
   def "create interacts with gateway"() {

--- a/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/AchTransfersControllerTest.groovy
+++ b/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/AchTransfersControllerTest.groovy
@@ -33,7 +33,7 @@ class AchTransfersControllerTest extends Specification implements WithMockery {
   }
 
   def cleanup() {
-    AchTransfersController.clearRepository()
+    AchTransfersController.clearGateway()
   }
 
   def "list interacts with gateway"() {

--- a/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/AuthenticationControllerTest.groovy
+++ b/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/AuthenticationControllerTest.groovy
@@ -58,7 +58,7 @@ class AuthenticationControllerTest extends Specification implements WithMockery 
   }
 
   def cleanup() {
-    BaseController.clearRepository()
+    BaseController.clearGateway()
     Session.clearSession()
     Session.setRepositorySupplier(null)
     RequestContext.clear()

--- a/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/AuthorizationsControllerTest.groovy
+++ b/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/AuthorizationsControllerTest.groovy
@@ -26,7 +26,7 @@ class AuthorizationsControllerTest extends Specification {
   }
 
   def cleanup() {
-    BaseController.clearRepository()
+    BaseController.clearGateway()
   }
 
   def "createAuthorization interacts with gateway"() {

--- a/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/BillsControllerTest.groovy
+++ b/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/BillsControllerTest.groovy
@@ -30,7 +30,7 @@ class BillsControllerTest extends Specification implements WithMockery {
   }
 
   def cleanup() {
-    BaseController.clearRepository()
+    BaseController.clearGateway()
   }
 
   def "getBill interacts with gateway"() {

--- a/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/CheckImagesControllerTest.groovy
+++ b/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/CheckImagesControllerTest.groovy
@@ -43,7 +43,7 @@ class CheckImagesControllerTest extends Specification implements WithMockery{
   }
 
   def cleanup() {
-    BaseController.clearRepository()
+    BaseController.clearGateway()
   }
 
   def "getCheckImages interacts with gateway"() {

--- a/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/CreditReportControllerTest.groovy
+++ b/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/CreditReportControllerTest.groovy
@@ -35,7 +35,7 @@ class CreditReportControllerTest extends Specification implements WithMockery {
   }
 
   def cleanup() {
-    CreditReportController.clearRepository()
+    CreditReportController.clearGateway()
   }
 
   def "getCreditReportSettings interacts with gateway"() {

--- a/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/CrossAccountRecurringTransferControllerTest.groovy
+++ b/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/CrossAccountRecurringTransferControllerTest.groovy
@@ -30,7 +30,7 @@ class CrossAccountRecurringTransferControllerTest extends Specification{
   }
 
   def cleanup() {
-    CrossAccountRecurringTransferController.clearRepository()
+    CrossAccountRecurringTransferController.clearGateway()
   }
 
   def "createCrossAccountRecurringTransfer interacts with gateway"() {

--- a/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/CrossAccountTransferDestinationControllerTest.groovy
+++ b/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/CrossAccountTransferDestinationControllerTest.groovy
@@ -29,7 +29,7 @@ class CrossAccountTransferDestinationControllerTest  extends Specification {
   }
 
   def cleanup() {
-    CrossAccountTransferDestinationController.clearRepository()
+    CrossAccountTransferDestinationController.clearGateway()
   }
 
   def "createDestination interacts with gateway"() {

--- a/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/CrossAccountTransferFeesControllerTest.groovy
+++ b/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/CrossAccountTransferFeesControllerTest.groovy
@@ -32,7 +32,7 @@ class CrossAccountTransferFeesControllerTest extends Specification implements Wi
   }
 
   def cleanup() {
-    BaseController.clearRepository()
+    BaseController.clearGateway()
   }
 
   def "list fees with options interacts with gateway"() {

--- a/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/CrossAccountTransferFrequencyControllerTest.groovy
+++ b/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/CrossAccountTransferFrequencyControllerTest.groovy
@@ -29,7 +29,7 @@ class CrossAccountTransferFrequencyControllerTest extends Specification {
   }
 
   def cleanup() {
-    CrossAccountTransferFrequencyController.clearRepository()
+    CrossAccountTransferFrequencyController.clearGateway()
   }
 
   def "list Frequencies for cross accounts interacts with gateway"() {

--- a/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/CrossAccountTransfersControllerTest.groovy
+++ b/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/CrossAccountTransfersControllerTest.groovy
@@ -34,7 +34,7 @@ class CrossAccountTransfersControllerTest extends Specification implements WithM
   }
 
   def cleanup() {
-    AccountsController.clearRepository()
+    AccountsController.clearGateway()
   }
 
   def "createCrossAccountTransfer interacts with gateway"() {

--- a/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/DisputedTransactionsControllerTest.groovy
+++ b/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/DisputedTransactionsControllerTest.groovy
@@ -36,7 +36,7 @@ class DisputedTransactionsControllerTest extends Specification {
   }
 
   def cleanup() {
-    BaseController.clearRepository()
+    BaseController.clearGateway()
   }
 
   def "createDisputedTransaction interacts with gateway"() {

--- a/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/DisputesControllerTest.groovy
+++ b/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/DisputesControllerTest.groovy
@@ -33,7 +33,7 @@ class DisputesControllerTest extends Specification {
   }
 
   def cleanup() {
-    BaseController.clearRepository()
+    BaseController.clearGateway()
   }
 
   def "cancelDispute interacts with gateway"() {

--- a/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/DocumentsControllerTest.groovy
+++ b/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/DocumentsControllerTest.groovy
@@ -27,7 +27,7 @@ class DocumentsControllerTest extends Specification {
   }
 
   def cleanup() {
-    BaseController.clearRepository()
+    BaseController.clearGateway()
   }
 
   def "getDocument interacts with gateway"() {

--- a/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/LocationsControllerTest.groovy
+++ b/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/LocationsControllerTest.groovy
@@ -26,7 +26,7 @@ class LocationsControllerTest extends Specification {
   }
 
   def cleanup() {
-    LocationsController.clearRepository()
+    LocationsController.clearGateway()
   }
 
   def "getLocation interacts with gateway"() {

--- a/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/ManagedCardsControllerTest.groovy
+++ b/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/ManagedCardsControllerTest.groovy
@@ -30,7 +30,7 @@ class ManagedCardsControllerTest extends Specification {
   }
 
   def cleanup() {
-    BaseController.clearRepository()
+    BaseController.clearGateway()
   }
 
   def "get interacts with gateway"() {

--- a/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/MerchantsControllerTest.groovy
+++ b/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/MerchantsControllerTest.groovy
@@ -32,7 +32,7 @@ class MerchantsControllerTest extends Specification {
   }
 
   def cleanup() {
-    BaseController.clearRepository()
+    BaseController.clearGateway()
   }
 
   def "getMerchantCategoryList interacts with gateway"() {

--- a/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/OriginationsControllerTest.groovy
+++ b/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/OriginationsControllerTest.groovy
@@ -37,7 +37,7 @@ class OriginationsControllerTest extends Specification {
   }
 
   def cleanup() {
-    BaseController.clearRepository()
+    BaseController.clearGateway()
     Session.clearSession()
     Session.setRepositorySupplier(null)
   }

--- a/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/PayeesControllerTest.groovy
+++ b/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/PayeesControllerTest.groovy
@@ -31,7 +31,7 @@ class PayeesControllerTest extends Specification {
   }
 
   def cleanup() {
-    BaseController.clearRepository()
+    BaseController.clearGateway()
   }
 
   def "getPayees interacts with gateway"() {

--- a/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/PaymentsControllerTest.groovy
+++ b/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/PaymentsControllerTest.groovy
@@ -28,7 +28,7 @@ class PaymentsControllerTest extends Specification {
   }
 
   def cleanup() {
-    BaseController.clearRepository()
+    BaseController.clearGateway()
   }
 
   def "getPayment interacts with gateway"() {

--- a/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/PayoutsControllerTest.groovy
+++ b/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/PayoutsControllerTest.groovy
@@ -37,7 +37,7 @@ class PayoutsControllerTest extends Specification implements WithMockery {
   }
 
   def cleanup() {
-    BaseController.clearRepository()
+    BaseController.clearGateway()
   }
 
   def "ListPayoutFromAccounts interacts with gateway"() {

--- a/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/ProfilesControllerTest.groovy
+++ b/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/ProfilesControllerTest.groovy
@@ -46,7 +46,7 @@ class ProfilesControllerTest extends Specification {
   }
 
   def cleanup() {
-    ProfilesController.clearRepository()
+    ProfilesController.clearGateway()
   }
 
   def "getProfile_implemented"() {

--- a/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/RecurringPaymentsControllerTest.groovy
+++ b/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/RecurringPaymentsControllerTest.groovy
@@ -30,7 +30,7 @@ class RecurringPaymentsControllerTest extends Specification {
   }
 
   def cleanup() {
-    BaseController.clearRepository()
+    BaseController.clearGateway()
   }
 
   def "index recurring payment frequencies invokes gateway"() {

--- a/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/RecurringTransferFrequenciesControllerTest.groovy
+++ b/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/RecurringTransferFrequenciesControllerTest.groovy
@@ -38,7 +38,7 @@ class RecurringTransferFrequenciesControllerTest extends Specification implement
   }
 
   def cleanup() {
-    BaseController.clearRepository()
+    BaseController.clearGateway()
   }
 
   def "getRecurringTransferFrequencies interacts with gateway"() {

--- a/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/RecurringTransfersControllerTest.groovy
+++ b/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/RecurringTransfersControllerTest.groovy
@@ -34,7 +34,7 @@ class RecurringTransfersControllerTest extends Specification implements WithMock
   }
 
   def cleanup() {
-    BaseController.clearRepository()
+    BaseController.clearGateway()
   }
 
   def "createRecurringTransfer interacts with gateway"() {

--- a/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/RemoteDepositsControllerTest.groovy
+++ b/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/RemoteDepositsControllerTest.groovy
@@ -27,7 +27,7 @@ class RemoteDepositsControllerTest extends Specification {
   }
 
   def cleanup() {
-    BaseController.clearRepository()
+    BaseController.clearGateway()
   }
 
   def "getRemoteDeposit interacts with gateway"() {

--- a/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/StatusControllerTest.groovy
+++ b/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/StatusControllerTest.groovy
@@ -7,8 +7,6 @@ import com.mx.path.core.common.accessor.PathResponseStatus
 import com.mx.path.gateway.accessor.AccessorResponse
 import com.mx.path.gateway.api.Gateway
 import com.mx.path.gateway.api.StatusGateway
-import com.mx.path.model.mdx.web.controller.BaseController
-import com.mx.path.model.mdx.web.controller.StatusController
 
 import org.mockito.Mockito
 import org.springframework.http.HttpStatus
@@ -28,7 +26,7 @@ class StatusControllerTest extends Specification {
   }
 
   def cleanup() {
-    BaseController.clearRepository()
+    BaseController.clearGateway()
   }
 
   def "getStatus interacts with gateway"() {

--- a/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/TransferAccountsControllerTest.groovy
+++ b/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/TransferAccountsControllerTest.groovy
@@ -34,7 +34,7 @@ class TransferAccountsControllerTest extends Specification {
   }
 
   def cleanup() {
-    TransfersController.clearRepository()
+    TransfersController.clearGateway()
   }
 
   def "getAccounts interacts with gateway"() {

--- a/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/TransferAmountOptionsControllerTest.groovy
+++ b/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/TransferAmountOptionsControllerTest.groovy
@@ -40,7 +40,7 @@ class TransferAmountOptionsControllerTest extends Specification {
   }
 
   def cleanup() {
-    TransfersController.clearRepository()
+    TransfersController.clearGateway()
   }
 
   def "list transfer amount options interacts with gateway"() {

--- a/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/TransferFeesControllerTest.groovy
+++ b/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/TransferFeesControllerTest.groovy
@@ -33,7 +33,7 @@ class TransferFeesControllerTest extends Specification implements WithMockery {
   }
 
   def cleanup() {
-    BaseController.clearRepository()
+    BaseController.clearGateway()
   }
 
   def "list fees by id interacts with gateway"() {

--- a/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/TransferRepaymentsControllerTest.groovy
+++ b/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/TransferRepaymentsControllerTest.groovy
@@ -35,7 +35,7 @@ class TransferRepaymentsControllerTest extends Specification implements WithMock
   }
 
   def cleanup() {
-    BaseController.clearRepository()
+    BaseController.clearGateway()
   }
 
   def "list repayments interacts with gateway"() {

--- a/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/TransfersControllerTest.groovy
+++ b/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/TransfersControllerTest.groovy
@@ -31,7 +31,7 @@ class TransfersControllerTest extends Specification {
   }
 
   def cleanup() {
-    TransfersController.clearRepository()
+    TransfersController.clearGateway()
   }
 
   def "createTransfer interacts with gateway"() {


### PR DESCRIPTION
# Summary of Changes

Change name of clearRepository to clearGateway. Repository is an old term. This was confusing.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
