### PR TITLE
Fix header forwarding

### DIFF
--- a/mdx-web/src/main/java/com/mx/path/model/mdx/web/filter/ErrorHandler.java
+++ b/mdx-web/src/main/java/com/mx/path/model/mdx/web/filter/ErrorHandler.java
@@ -16,6 +16,7 @@ import com.mx.path.core.common.exception.ExceptionReporter;
 import com.mx.path.core.common.exception.PathRequestException;
 import com.mx.path.core.common.exception.PathRequestExceptionWrapper;
 import com.mx.path.core.context.RequestContext;
+import com.mx.path.core.context.ResponseContext;
 import com.mx.path.core.context.Session;
 import com.mx.path.core.context.facility.Facilities;
 
@@ -104,6 +105,12 @@ class ErrorHandler {
     response.setStatus(status.value());
     response.setContentType("application/vnd.mx.mdx.v6+json");
 
+    // Attach response context headers
+    if (ResponseContext.current() != null && ResponseContext.current().getHeaders() != null) {
+      ResponseContext.current().getHeaders().forEach(response::setHeader);
+    }
+
+    // Attach exception headers (these take precedence)
     if (headers != null) {
       headers.forEach(response::setHeader);
     }


### PR DESCRIPTION
# Summary of Changes

## Handle Response Headers

### For non-error responses

Use .set instead of .add to make sure there is only one value. Setting precedence order will clear up any conflicts. Multiple headers could cause unexpected issues.

### For error responses

Response context headers were not being forwarded. This corrects that.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
