### PR TITLE
feat: add user route verification against session user

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
   id "io.github.gradle-nexus.publish-plugin" version "1.1.+"
 }
 
-version "4.14.2" // x-release-please-version
+version "3.11.0-rc.1" // x-release-please-version
 
 def platformProject = "platform"
 def publishedProjects = [

--- a/mdx-web/src/main/java/com/mx/path/model/mdx/web/PathTools.java
+++ b/mdx-web/src/main/java/com/mx/path/model/mdx/web/PathTools.java
@@ -62,6 +62,7 @@ public class PathTools {
    */
   private static final Pattern PATH_CLIENT_GUID_PATTERN = Pattern.compile("^\\/((?<clientId>[^\\/]+)\\/.*)");
   private static final Pattern PATH_SESSION_ID_PATTERN = Pattern.compile("^\\/[^\\/]+\\/authentications\\/(?<sessionId>[^\\/]+)\\/sso\\/*");
+  private static final Pattern PATH_USER_ID_PATTERN = Pattern.compile("^\\/[^\\/]+\\/users\\/(?<userId>[^\\/]+)\\/.*$");
 
   /**
    * Extract the ClientId from a path
@@ -102,6 +103,10 @@ public class PathTools {
     return AUTHENTICATION_REQUIRED_PATHS.stream().anyMatch(p -> p.test(path));
   }
 
+  public static boolean isUserRequiredPath(String path) {
+    return PATH_USER_ID_PATTERN.asPredicate().test(path);
+  }
+
   public static String extractSessionId(String path) {
     Matcher sessionIdMatcher = PATH_SESSION_ID_PATTERN.matcher(path);
     if (sessionIdMatcher.matches()) {
@@ -109,5 +114,10 @@ public class PathTools {
     }
 
     return null;
+  }
+
+  public static String extractUserId(String path) {
+    Matcher userIdMatcher = PATH_USER_ID_PATTERN.matcher(path);
+    return userIdMatcher.matches() ? userIdMatcher.group("userId") : null;
   }
 }

--- a/mdx-web/src/main/java/com/mx/path/model/mdx/web/filter/RequireAuthenticationFilter.java
+++ b/mdx-web/src/main/java/com/mx/path/model/mdx/web/filter/RequireAuthenticationFilter.java
@@ -8,6 +8,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import com.mx.path.core.common.accessor.UnauthorizedException;
+import com.mx.path.core.common.lang.Strings;
 import com.mx.path.core.context.Session;
 import com.mx.path.core.context.Session.SessionState;
 import com.mx.path.model.mdx.web.PathTools;
@@ -48,8 +49,11 @@ public class RequireAuthenticationFilter extends OncePerRequestFilter {
     }
 
     if (PathTools.isUserRequiredPath(path)) {
+      if (Strings.isBlank(Session.current().getUserId())) {
+        throw new UnauthorizedException("UserId missing in authenticated session", "Not Authenticated");
+      }
       String userId = PathTools.extractUserId(path);
-      if (userId != null && Session.current().getUserId() != null && !userId.equals(Session.current().getUserId())) {
+      if (userId != null && !userId.equals(Session.current().getUserId())) {
         throw new UnauthorizedException("User does not match user session", "Not Authenticated");
       }
     }

--- a/mdx-web/src/main/java/com/mx/path/model/mdx/web/filter/RequireAuthenticationFilter.java
+++ b/mdx-web/src/main/java/com/mx/path/model/mdx/web/filter/RequireAuthenticationFilter.java
@@ -49,7 +49,7 @@ public class RequireAuthenticationFilter extends OncePerRequestFilter {
 
     if (PathTools.isUserRequiredPath(path)) {
       String userId = PathTools.extractUserId(path);
-      if (userId != null && !userId.equals(Session.current().getUserId())) {
+      if (userId != null && Session.current().getUserId() != null && !userId.equals(Session.current().getUserId())) {
         throw new UnauthorizedException("User does not match user session", "Not Authenticated");
       }
     }

--- a/mdx-web/src/main/java/com/mx/path/model/mdx/web/filter/RequireAuthenticationFilter.java
+++ b/mdx-web/src/main/java/com/mx/path/model/mdx/web/filter/RequireAuthenticationFilter.java
@@ -28,6 +28,7 @@ import org.springframework.web.filter.OncePerRequestFilter;
 public class RequireAuthenticationFilter extends OncePerRequestFilter {
 
   @Override
+  @SuppressWarnings("PMD.CyclomaticComplexity")
   protected final void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
       throws ServletException, IOException {
     String path = request.getServletPath();
@@ -46,6 +47,12 @@ public class RequireAuthenticationFilter extends OncePerRequestFilter {
       throw new UnauthorizedException("Not Authenticated", "Not Authenticated");
     }
 
+    if (PathTools.isUserRequiredPath(path)) {
+      String userId = PathTools.extractUserId(path);
+      if (userId != null && !userId.equals(Session.current().getUserId())) {
+        throw new UnauthorizedException("User does not match user session", "Not Authenticated");
+      }
+    }
     filterChain.doFilter(request, response);
   }
 }

--- a/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/PathToolsTest.groovy
+++ b/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/PathToolsTest.groovy
@@ -29,6 +29,14 @@ class PathToolsTest extends Specification {
     PathTools.isAuthenticationPath("/hughes/authentications/start")
   }
 
+  def "isUserRequiredPath"() {
+    expect:
+    !PathTools.isUserRequiredPath("/hughes/authentications")
+    !PathTools.isUserRequiredPath("/hughes/authentications/")
+    !PathTools.isUserRequiredPath("/hughes/authentications/start")
+    PathTools.isUserRequiredPath("/hughes/users/U-197191/accounts")
+  }
+
   def "isAuthenticationPathIsFalseOnLogoutAndMFARoutes"() {
     expect:
     !PathTools.isAuthenticationPath("/hughes/authentications/session-1234")
@@ -50,5 +58,10 @@ class PathToolsTest extends Specification {
   def "extractSessionId"() {
     expect:
     PathTools.extractSessionId("/hughes/authentications/session-1234/sso") == "session-1234"
+  }
+
+  def "extractUserId"() {
+    expect:
+    PathTools.extractUserId("/hughes/users/U-197191/accounts") == "U-197191"
   }
 }

--- a/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/filter/RequireAuthenticationFilterTest.groovy
+++ b/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/filter/RequireAuthenticationFilterTest.groovy
@@ -134,6 +134,21 @@ class RequireAuthenticationFilterTest extends Specification {
     err.userMessage == "Not Authenticated"
   }
 
+  def "userRouteWithMissingSessionUserId"() {
+    given:
+    Session.createSession()
+    Session.current().setSessionState(Session.SessionState.AUTHENTICATED)
+    setPath("/hughes/users/U-197191/accounts")
+
+    when:
+    subject.doFilter(request, response, filterChain)
+
+    then:
+    def err = thrown(UnauthorizedException)
+    err.message == "UserId missing in authenticated session"
+    err.userMessage == "Not Authenticated"
+  }
+
   private void setPath(String path) {
     request.getServletPath() >> path
   }

--- a/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/filter/RequireAuthenticationFilterTest.groovy
+++ b/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/filter/RequireAuthenticationFilterTest.groovy
@@ -118,6 +118,22 @@ class RequireAuthenticationFilterTest extends Specification {
     subject.doFilter(request, response, filterChain)
   }
 
+  def "userRouteWithDifferentUserIdFromSessionUserId"() {
+    given:
+    Session.createSession()
+    Session.current().setUserId("user123")
+    Session.current().setSessionState(Session.SessionState.AUTHENTICATED)
+    setPath("/hughes/users/U-197191/accounts")
+
+    when:
+    subject.doFilter(request, response, filterChain)
+
+    then:
+    def err = thrown(UnauthorizedException)
+    err.message == "User does not match user session"
+    err.userMessage == "Not Authenticated"
+  }
+
   private void setPath(String path) {
     request.getServletPath() >> path
   }


### PR DESCRIPTION
# Summary of Changes

Ensures `UserId` matches `UserId` in the underlying session correlated to MdxSessionKey before allowing request to continue

Fixes [#727](https://gitlab.mx.com/mx/experiences/live-client-stability/live-client-stability-issues/-/issues/727)

## Public API Additions/Changes

No changes to users interaction with API

## Downstream Consumer Impact

This adds another layer of security against a user trying to access another users data using a session that does not belong to the other user.

# How Has This Been Tested?

- [x] PathToolsTest.extractUserId()
- [x] PathToolsTest.isUserRequiredPath()
- [x] RequireAuthenticationFilterTest.userRouteWithDifferentUserIdFromSessionUserId()
- [x] Manual Verification on several clients and every MDX feature

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
