### PR TITLE
feat: added remoteDepositEnrolled field to RemoteUser

### DIFF
--- a/mdx-models/src/main/java/com/mx/path/api/connect/messaging/remote/models/RemoteUser.java
+++ b/mdx-models/src/main/java/com/mx/path/api/connect/messaging/remote/models/RemoteUser.java
@@ -20,6 +20,7 @@ public class RemoteUser extends MdxBase<RemoteUser> {
   private String lastName;
   private String phone;
   private Boolean remoteDepositEligible;
+  private Boolean remoteDepositEnrolled;
   private String ssn;
   private String state;
   private String postalCode;


### PR DESCRIPTION
# Summary of Changes

We've decided to make some small changes to the RemoteUser code in Ultraman to make more sense. With the addition of Remote User features in abagnale (including the creation of a tracking record) we want to add the Boolean `remoteDepositEnrolled` so it can be passed through nats and used in the update method for RemoteUserService.

Fixes # [(issue) ](https://gitlab.mx.com/mx/experiences/global-cu/global-cu-issues/-/issues/350)

## Public API Additions/Changes

Adding remoteDepositEnrolled as a field in RemoteUSer

## Downstream Consumer Impact

No breaking changes, just adding a field

# How Has This Been Tested?

A conditional in Ultraman that checks the boolean and runs RDC enrollment code based off of it. Tests have been run locally checking the existing boolean

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
