### PR TITLE
fix: get to enrollment and settings should not expect content-type he…

### DIFF
--- a/mdx-web/src/main/java/com/mx/path/model/mdx/web/controller/PaymentsController.java
+++ b/mdx-web/src/main/java/com/mx/path/model/mdx/web/controller/PaymentsController.java
@@ -19,7 +19,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping(value = "{clientId}/users/{user_id}", produces = BaseController.MDX_MEDIA)
 public class PaymentsController extends BaseController {
 
-  @RequestMapping(value = "/payments/enrollment", method = RequestMethod.GET, consumes = BaseController.MDX_MEDIA)
+  @RequestMapping(value = "/payments/enrollment", method = RequestMethod.GET)
   public final ResponseEntity<Enrollment> getPaymentEnrollment() {
     AccessorResponse<Enrollment> response = gateway().payments().enrollment();
     return new ResponseEntity<>(response.getResult().wrapped(), createMultiMapForResponse(response.getHeaders()), HttpStatus.OK);
@@ -31,7 +31,7 @@ public class PaymentsController extends BaseController {
     return new ResponseEntity<>(response.getResult().wrapped(), createMultiMapForResponse(response.getHeaders()), HttpStatus.OK);
   }
 
-  @RequestMapping(value = "/payments/settings", method = RequestMethod.GET, consumes = BaseController.MDX_MEDIA)
+  @RequestMapping(value = "/payments/settings", method = RequestMethod.GET)
   public final ResponseEntity<Settings> getPaymentSettings() {
     AccessorResponse<Settings> response = gateway().payments().settings();
     Settings result = response.getResult();


### PR DESCRIPTION
# Summary of Changes

Removes `consumes` from request mapping for `getPaymentSettings` and `getPaymentEnrollment`

Fixes # (issue)
https://gitlab.mx.com/mx/experiences/hancock-whitney/hancock-whitney/-/issues/331

## Public API Additions/Changes

Changes expected headers for GET to `/payment/settings` and `/payment/enrollment`
No longer expects Content-Type header

## Downstream Consumer Impact

No breaking changes

# How Has This Been Tested?

Tested locally

- [ ] Test A
- [ ] Test B

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
