### PR TITLE
feat: add list and update challenge questions endpoints

### DIFF
--- a/mdx-models/src/main/java/com/mx/path/model/mdx/accessor/profile/ChallengeQuestionBaseAccessor.java
+++ b/mdx-models/src/main/java/com/mx/path/model/mdx/accessor/profile/ChallengeQuestionBaseAccessor.java
@@ -1,0 +1,46 @@
+package com.mx.path.model.mdx.accessor.profile;
+
+import com.mx.path.core.common.accessor.API;
+import com.mx.path.core.common.accessor.AccessorMethodNotImplementedException;
+import com.mx.path.core.common.gateway.GatewayAPI;
+import com.mx.path.core.common.gateway.GatewayClass;
+import com.mx.path.gateway.accessor.Accessor;
+import com.mx.path.gateway.accessor.AccessorConfiguration;
+import com.mx.path.gateway.accessor.AccessorResponse;
+import com.mx.path.model.mdx.model.profile.ChallengeQuestions;
+
+/**
+ * Accessor base for profile challenge questions
+ */
+@GatewayClass
+@API(specificationUrl = "https://developer.mx.com/drafts/mdx/profile/index.html#challenge-questions")
+public class ChallengeQuestionBaseAccessor extends Accessor {
+  public ChallengeQuestionBaseAccessor() {
+  }
+
+  @Deprecated
+  public ChallengeQuestionBaseAccessor(AccessorConfiguration configuration) {
+    super(configuration);
+  }
+
+  /**
+   * Lists challenge questions
+   * @return
+   */
+  @GatewayAPI
+  @API(description = "List challenge questions")
+  public AccessorResponse<ChallengeQuestions> list() {
+    throw new AccessorMethodNotImplementedException();
+  }
+
+  /**
+   * Updates challenge questions
+   * @param challengeQuestions
+   * @return
+   */
+  @GatewayAPI
+  @API(description = "update challenge questions")
+  public AccessorResponse<ChallengeQuestions> update(ChallengeQuestions challengeQuestions) {
+    throw new AccessorMethodNotImplementedException();
+  }
+}

--- a/mdx-models/src/main/java/com/mx/path/model/mdx/accessor/profile/ProfileBaseAccessor.java
+++ b/mdx-models/src/main/java/com/mx/path/model/mdx/accessor/profile/ProfileBaseAccessor.java
@@ -31,6 +31,10 @@ public class ProfileBaseAccessor extends Accessor {
 
   @GatewayAPI
   @Getter(AccessLevel.PROTECTED)
+  private ChallengeQuestionBaseAccessor challengeQuestions;
+
+  @GatewayAPI
+  @Getter(AccessLevel.PROTECTED)
   private EmailBaseAccessor emails;
 
   @GatewayAPI
@@ -70,6 +74,29 @@ public class ProfileBaseAccessor extends Accessor {
    */
   public void setAddresses(AddressBaseAccessor addresses) {
     this.addresses = addresses;
+  }
+
+  /**
+   * Accessor for challenge question operations
+   *
+   * @return accessor
+   */
+  @API(specificationUrl = "https://developer.mx.com/drafts/mdx/profile/index.html#challenge-questions")
+  public ChallengeQuestionBaseAccessor challengeQuestions() {
+    if (challengeQuestions != null) {
+      return challengeQuestions;
+    }
+
+    throw new AccessorMethodNotImplementedException();
+  }
+
+  /**
+   * Set challege questions accessor
+   *
+   * @param challengeQuestions
+   */
+  public void setChallengeQuestions(ChallengeQuestionBaseAccessor challengeQuestions) {
+    this.challengeQuestions = challengeQuestions;
   }
 
   /**

--- a/mdx-models/src/main/java/com/mx/path/model/mdx/model/Resources.java
+++ b/mdx-models/src/main/java/com/mx/path/model/mdx/model/Resources.java
@@ -76,6 +76,7 @@ import com.mx.path.model.mdx.model.payout.Question;
 import com.mx.path.model.mdx.model.payout.Recipient;
 import com.mx.path.model.mdx.model.payout.RecurringPayout;
 import com.mx.path.model.mdx.model.profile.Address;
+import com.mx.path.model.mdx.model.profile.ChallengeQuestions;
 import com.mx.path.model.mdx.model.profile.Email;
 import com.mx.path.model.mdx.model.profile.Password;
 import com.mx.path.model.mdx.model.profile.Phone;
@@ -292,6 +293,8 @@ public class Resources {
     }.getType(), new ModelWrappableSerializer("profiles"));
     // Addresses
     builder.registerTypeAdapter(Address.class, new ModelWrappableSerializer("address"));
+    // Challenge Questions
+    builder.registerTypeAdapter(ChallengeQuestions.class, new ModelWrappableSerializer("challenge_questions"));
     builder.registerTypeAdapter(new TypeToken<MdxList<Address>>() {
     }.getType(), new ModelWrappableSerializer("addresses"));
     // Phones

--- a/mdx-models/src/main/java/com/mx/path/model/mdx/model/profile/ChallengeQuestions.java
+++ b/mdx-models/src/main/java/com/mx/path/model/mdx/model/profile/ChallengeQuestions.java
@@ -1,0 +1,15 @@
+package com.mx.path.model.mdx.model.profile;
+
+import java.util.List;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+import com.mx.path.model.mdx.model.MdxBase;
+import com.mx.path.model.mdx.model.challenges.Challenge;
+
+@EqualsAndHashCode(callSuper = true)
+@Data
+public final class ChallengeQuestions extends MdxBase<ChallengeQuestions> {
+  private List<Challenge> challenges;
+}

--- a/mdx-web/src/main/java/com/mx/path/model/mdx/web/controller/ProfilesController.java
+++ b/mdx-web/src/main/java/com/mx/path/model/mdx/web/controller/ProfilesController.java
@@ -4,6 +4,7 @@ import com.mx.path.gateway.accessor.AccessorResponse;
 import com.mx.path.model.mdx.model.MdxList;
 import com.mx.path.model.mdx.model.challenges.Challenge;
 import com.mx.path.model.mdx.model.profile.Address;
+import com.mx.path.model.mdx.model.profile.ChallengeQuestions;
 import com.mx.path.model.mdx.model.profile.Email;
 import com.mx.path.model.mdx.model.profile.Password;
 import com.mx.path.model.mdx.model.profile.Phone;
@@ -65,6 +66,23 @@ public class ProfilesController extends BaseController {
   @RequestMapping(value = "/users/{userId}/profile/addresses/{addressId}", method = RequestMethod.DELETE)
   public final ResponseEntity<?> deleteAddress(@PathVariable("addressId") String addressId) {
     AccessorResponse<Void> response = gateway().profiles().addresses().delete(addressId);
+    return new ResponseEntity<>(createMultiMapForResponse(response.getHeaders()), HttpStatus.NO_CONTENT);
+  }
+
+  @RequestMapping(value = "/users/{userId}/profile/challenge_questions", method = RequestMethod.GET)
+  public final ResponseEntity<ChallengeQuestions> getChallengeQuestions() {
+    AccessorResponse<ChallengeQuestions> response = gateway().profiles().challengeQuestions().list();
+    return new ResponseEntity<>(response.getResult().wrapped(), createMultiMapForResponse(response.getHeaders()), HttpStatus.ACCEPTED);
+  }
+
+  @RequestMapping(value = "/users/{userId}/profile/challenge_questions", method = RequestMethod.PUT, consumes = MDX_MEDIA)
+  public final ResponseEntity<?> updateChallengeQuestions(@RequestBody ChallengeQuestions challengeQuestions) {
+    AccessorResponse<ChallengeQuestions> response = gateway().profiles().challengeQuestions().update(challengeQuestions);
+
+    ChallengeQuestions result = response.getResult();
+    if (result.getChallenges() != null && !result.getChallenges().isEmpty()) {
+      return new ResponseEntity<>(response.getResult().wrapped(), createMultiMapForResponse(response.getHeaders()), HttpStatus.ACCEPTED);
+    }
     return new ResponseEntity<>(createMultiMapForResponse(response.getHeaders()), HttpStatus.NO_CONTENT);
   }
 

--- a/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/ProfilesControllerTest.groovy
+++ b/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/ProfilesControllerTest.groovy
@@ -8,12 +8,14 @@ import static org.mockito.Mockito.verify
 import com.mx.path.gateway.accessor.AccessorResponse
 import com.mx.path.gateway.api.Gateway
 import com.mx.path.gateway.api.profile.AddressGateway
+import com.mx.path.gateway.api.profile.ChallengeQuestionGateway
 import com.mx.path.gateway.api.profile.EmailGateway
 import com.mx.path.gateway.api.profile.PhoneGateway
 import com.mx.path.gateway.api.profile.ProfileGateway
 import com.mx.path.model.mdx.model.MdxList
 import com.mx.path.model.mdx.model.challenges.Challenge
 import com.mx.path.model.mdx.model.profile.Address
+import com.mx.path.model.mdx.model.profile.ChallengeQuestions
 import com.mx.path.model.mdx.model.profile.Email
 import com.mx.path.model.mdx.model.profile.Password
 import com.mx.path.model.mdx.model.profile.Phone
@@ -29,6 +31,7 @@ class ProfilesControllerTest extends Specification {
   Gateway gateway
   ProfileGateway profileGateway
   AddressGateway addressGateway
+  ChallengeQuestionGateway challengeQuestionGateway
   EmailGateway emailGateway
   PhoneGateway phoneGateway
   String clientId
@@ -37,9 +40,10 @@ class ProfilesControllerTest extends Specification {
     clientId = "client123"
 
     addressGateway = spy(AddressGateway.builder().clientId(clientId).build())
+    challengeQuestionGateway = spy(ChallengeQuestionGateway.builder().clientId(clientId).build())
     emailGateway = spy(EmailGateway.builder().clientId(clientId).build())
     phoneGateway = spy(PhoneGateway.builder().clientId(clientId).build())
-    profileGateway = spy(ProfileGateway.builder().clientId(clientId).emails(emailGateway).phones(phoneGateway).addresses(addressGateway).build())
+    profileGateway = spy(ProfileGateway.builder().clientId(clientId).emails(emailGateway).phones(phoneGateway).addresses(addressGateway).challengeQuestions(challengeQuestionGateway).build())
     gateway = spy(Gateway.builder().clientId(clientId).profiles(profileGateway).build())
 
     subject = new ProfilesController()
@@ -147,6 +151,59 @@ class ProfilesControllerTest extends Specification {
     response.body == mockResponse.result
     response.body.wrapped
     response.statusCode == HttpStatus.OK
+  }
+
+  def "getChallengeQuestions_implemented"() {
+    given:
+    ProfilesController.setGateway(gateway)
+
+    def mockResponse = new AccessorResponse<ChallengeQuestions>().withResult(new ChallengeQuestions())
+    doReturn(mockResponse).when(challengeQuestionGateway).list()
+
+    when:
+    def response = subject.getChallengeQuestions()
+
+    then:
+    response.body == mockResponse.result
+    response.body.wrapped
+    response.statusCode == HttpStatus.ACCEPTED
+  }
+
+  def "updateChallengeQuestions_implemented response is 202"() {
+    given:
+    ProfilesController.setGateway(gateway)
+
+    def body = new ChallengeQuestions()
+    def challenges = new MdxList()
+    challenges.add(new Challenge())
+
+    def mockResponse = new AccessorResponse<ChallengeQuestions>().withResult(new ChallengeQuestions().tap {
+      setChallenges(challenges)
+    })
+    doReturn(mockResponse).when(challengeQuestionGateway).update(body)
+
+    when:
+    def response = subject.updateChallengeQuestions(body)
+
+    then:
+    response.body == mockResponse.result
+    response.body.wrapped
+    response.statusCode == HttpStatus.ACCEPTED
+  }
+
+  def "updateChallengeQuestions_implemented response is 204"() {
+    given:
+    ProfilesController.setGateway(gateway)
+
+    def body = new ChallengeQuestions()
+    def mockResponse = new AccessorResponse<ChallengeQuestions>().withResult(new ChallengeQuestions())
+    doReturn(mockResponse).when(challengeQuestionGateway).update(body)
+
+    when:
+    def response = subject.updateChallengeQuestions(body)
+
+    then:
+    response.statusCode == HttpStatus.NO_CONTENT
   }
 
   def "deleteAddress_implemented"() {


### PR DESCRIPTION
# Summary of Changes

- Adds `GET /profile/challenge_questions` which returns a 202 with challenge questions
- Adds `PUT /profile/challenge_questions` which can return a 202 if there are more challenge questions. Or a 204 if there are no more questions
- spec changes found here https://developer.mx.com/drafts/mdx/profile/index.html#challenge-questions

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
