### PR TITLE
Add new fields to the account model 

### DIFF
--- a/mdx-models/src/main/java/com/mx/path/model/mdx/model/account/Account.java
+++ b/mdx-models/src/main/java/com/mx/path/model/mdx/model/account/Account.java
@@ -32,6 +32,10 @@ public class Account extends MdxBase<Account> {
   private BigDecimal creditLimit;
   @XmlElement(name = "currency_code")
   private String currencyCode;
+  @XmlElement(name = "daily_deposit_limit_current")
+  private Double dailyDepositLimitCurrent;
+  @XmlElement(name = "daily_deposit_limit_total")
+  private Double dailyDepositLimitTotal;
   @XmlElement(name = "day_payment_is_due")
   private LocalDate dayPaymentIsDue;
   @XmlElement(name = "guid")
@@ -42,6 +46,10 @@ public class Account extends MdxBase<Account> {
   private BigDecimal holdTotal;
   @XmlElement(name = "id")
   private String id;
+  @XmlElement(name = "interest_paid_previous_year")
+  private Double interestPaidPreviousYear;
+  @XmlElement(name = "interest_paid_ytd")
+  private Double interestPaidYtd;
   @XmlElement(name = "interest_rate")
   private Double interestRate;
   @XmlElement(name = "is_closed")
@@ -54,6 +62,10 @@ public class Account extends MdxBase<Account> {
   private Long lastPaymentAt;
   @XmlElement(name = "last_payment_on")
   private LocalDate lastPaymentOn;
+  @XmlElement(name = "monthly_deposit_limit_current")
+  private Double monthlyDepositLimitCurrent;
+  @XmlElement(name = "monthly_deposit_limit_total")
+  private Double monthlyDepositLimitTotal;
   @XmlElement(name = "matures_at")
   private Long maturesAt;
   @XmlElement(name = "matures_on")
@@ -74,6 +86,8 @@ public class Account extends MdxBase<Account> {
   private String name;
   @XmlElement(name = "nickname")
   private String nickname;
+  @XmlElement(name = "next_payment")
+  private Double nextPayment;
   @XmlElement(name = "original_balance")
   private BigDecimal originalBalance;
   @XmlElement(name = "past_due_amount")
@@ -90,6 +104,8 @@ public class Account extends MdxBase<Account> {
   private BigDecimal pendingBalance;
   @XmlElement(name = "pending_transactions_total")
   private BigDecimal pendingTransactionsTotal;
+  @XmlElement(name = "principal_balance")
+  private Double principalBalance;
   @XmlElement(name = "routing_number")
   private String routingNumber;
   @Deprecated
@@ -103,6 +119,8 @@ public class Account extends MdxBase<Account> {
   private BigDecimal statementBalance;
   @XmlElement(name = "statement_closed_on")
   private LocalDate statementClosedOn;
+  @XmlElement(name = "statement_late_charges")
+  private Double statementLateCharges;
   @XmlElement(name = "subtype")
   private String subtype;
   @XmlElement(name = "type")
@@ -214,6 +232,22 @@ public class Account extends MdxBase<Account> {
     this.currencyCode = newCurrencyCode;
   }
 
+  public Double getDailyDepositLimitCurrent() {
+    return dailyDepositLimitCurrent;
+  }
+
+  public void setDailyDepositLimitCurrent(Double dailyDepositLimitCurrent) {
+    this.dailyDepositLimitCurrent = dailyDepositLimitCurrent;
+  }
+
+  public Double getDailyDepositLimitTotal() {
+    return dailyDepositLimitTotal;
+  }
+
+  public void setDailyDepositLimitTotal(Double dailyDepositLimitTotal) {
+    this.dailyDepositLimitTotal = dailyDepositLimitTotal;
+  }
+
   public final LocalDate getDayPaymentIsDue() {
     return dayPaymentIsDue;
   }
@@ -252,6 +286,22 @@ public class Account extends MdxBase<Account> {
 
   public final void setId(String newId) {
     this.id = newId;
+  }
+
+  public Double getInterestPaidPreviousYear() {
+    return interestPaidPreviousYear;
+  }
+
+  public void setInterestPaidPreviousYear(Double interestPaidPreviousYear) {
+    this.interestPaidPreviousYear = interestPaidPreviousYear;
+  }
+
+  public Double getInterestPaidYtd() {
+    return interestPaidYtd;
+  }
+
+  public void setInterestPaidYtd(Double interestPaidYtd) {
+    this.interestPaidYtd = interestPaidYtd;
   }
 
   public final Double getInterestRate() {
@@ -300,6 +350,22 @@ public class Account extends MdxBase<Account> {
 
   public final void setLastPaymentOn(LocalDate newLastPaymentOn) {
     this.lastPaymentOn = newLastPaymentOn;
+  }
+
+  public Double getMonthlyDepositLimitCurrent() {
+    return monthlyDepositLimitCurrent;
+  }
+
+  public void setMonthlyDepositLimitCurrent(Double monthlyDepositLimitCurrent) {
+    this.monthlyDepositLimitCurrent = monthlyDepositLimitCurrent;
+  }
+
+  public Double getMonthlyDepositLimitTotal() {
+    return monthlyDepositLimitTotal;
+  }
+
+  public void setMonthlyDepositLimitTotal(Double monthlyDepositLimitTotal) {
+    this.monthlyDepositLimitTotal = monthlyDepositLimitTotal;
   }
 
   public final Long getMaturesAt() {
@@ -382,6 +448,14 @@ public class Account extends MdxBase<Account> {
     this.nickname = newNickname;
   }
 
+  public Double getNextPayment() {
+    return nextPayment;
+  }
+
+  public void setNextPayment(Double nextPayment) {
+    this.nextPayment = nextPayment;
+  }
+
   public final BigDecimal getOriginalBalance() {
     return originalBalance;
   }
@@ -446,6 +520,14 @@ public class Account extends MdxBase<Account> {
     this.pendingTransactionsTotal = pendingTransactionsTotal;
   }
 
+  public Double getPrincipalBalance() {
+    return principalBalance;
+  }
+
+  public void setPrincipalBalance(Double principalBalance) {
+    this.principalBalance = principalBalance;
+  }
+
   public final String getRoutingNumber() {
     return routingNumber;
   }
@@ -492,6 +574,14 @@ public class Account extends MdxBase<Account> {
 
   public final void setStatementClosedOn(LocalDate newStatementClosedOn) {
     this.statementClosedOn = newStatementClosedOn;
+  }
+
+  public Double getStatementLateCharges() {
+    return statementLateCharges;
+  }
+
+  public void setStatementLateCharges(Double statementLateCharges) {
+    this.statementLateCharges = statementLateCharges;
   }
 
   public final String getSubtype() {

--- a/mdx-models/src/main/java/com/mx/path/model/mdx/model/account/StopPayment.java
+++ b/mdx-models/src/main/java/com/mx/path/model/mdx/model/account/StopPayment.java
@@ -9,6 +9,7 @@ import com.mx.path.model.mdx.model.MdxBase;
 @Data
 public class StopPayment extends MdxBase<StopPayment> {
   private Double amount;
+  private String effectiveDate;
   private String endingCheckNumber;
   private Double fee;
   private String id;


### PR DESCRIPTION
Summary of Changes

Adding 
daily_deposit_limit_current
daily_deposit_limit_total
interest_paid_previous_year
interest_paid_ytd
monthly_deposit_limit_current
monthly_deposit_limit_total
next_payment
principal_balance and
statement_late_charges to the Account model. 

Adding `effective_date` field to the Stop Payment model.

Adding `running_balance` field to the Transaction model.

The fields have been added the MDX spec https://developer.mx.com/mdx/v5/index.html#mdx-data-models-account-fields

https://gitlab.mx.com/mx/experiences/hancock-whitney/hancock-whitney/-/issues/458

Checklist:
 [ ] My code follows the style guidelines of this project
 [ ] I have performed a self-review of my code
 [ ] I have made corresponding changes to the documentation
 [ ] My changes generate no new warnings
 [ ] I have added tests that prove my fix is effective or that my feature works