### PR TITLE
fix: fixing the session issue for the reset password flow

### DIFF
--- a/mdx-web/src/main/java/com/mx/path/model/mdx/web/controller/AuthenticationController.java
+++ b/mdx-web/src/main/java/com/mx/path/model/mdx/web/controller/AuthenticationController.java
@@ -166,6 +166,10 @@ public class AuthenticationController extends BaseController {
 
   @RequestMapping(value = "/reset_password", method = RequestMethod.POST)
   public final ResponseEntity<ResetPassword> resetPassword() {
+    // Delete existing session if it exists;
+    Session.deleteCurrent();
+    Session.createSession();
+
     AccessorResponse<ResetPassword> response = gateway().id().resetPassword();
     return new ResponseEntity<>(response.getResult().wrapped(), createMultiMapForResponse(response.getHeaders()), HttpStatus.OK);
   }


### PR DESCRIPTION
# Summary of Changes

Creating a session when a user initiate the reset password flow

Fixes # (issue)

## Public API Additions/Changes

Going forward when a new request comes to the reset password flow a new session is established which we can use to recognize the user state in the reset password flow.

## Downstream Consumer Impact

Should not have any downstream impact on this

# How Has This Been Tested?

Verified that a new session is getting created and deleted if any old is passed along using the local testing.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
