### PR TITLE
fix: adding the documentation and sending the session key header in response

### DIFF
--- a/mdx-web/src/main/java/com/mx/path/model/mdx/web/controller/AuthenticationController.java
+++ b/mdx-web/src/main/java/com/mx/path/model/mdx/web/controller/AuthenticationController.java
@@ -165,7 +165,9 @@ public class AuthenticationController extends BaseController {
   }
 
   /***
-   * This endpoint always creates a new session when it called even if there is an existing session being passed
+   * Initiates the reset password workflow.
+   *
+   * Always creates a new session, discards old session
    *
    * @return
    */

--- a/mdx-web/src/main/java/com/mx/path/model/mdx/web/controller/AuthenticationController.java
+++ b/mdx-web/src/main/java/com/mx/path/model/mdx/web/controller/AuthenticationController.java
@@ -164,14 +164,22 @@ public class AuthenticationController extends BaseController {
     return new ResponseEntity<>(response.getResult().wrapped(), createMultiMapForResponse(response.getHeaders(), headers), status);
   }
 
+  /***
+   * This endpoint always creates a new session when it called even if there is an existing session being passed
+   *
+   * @return
+   */
   @RequestMapping(value = "/reset_password", method = RequestMethod.POST)
   public final ResponseEntity<ResetPassword> resetPassword() {
-    // Delete existing session if it exists;
+    //This endpoint always creates a new session when it called even if there is an existing session being passed
     Session.deleteCurrent();
     Session.createSession();
 
     AccessorResponse<ResetPassword> response = gateway().id().resetPassword();
-    return new ResponseEntity<>(response.getResult().wrapped(), createMultiMapForResponse(response.getHeaders()), HttpStatus.OK);
+
+    HttpHeaders headers = new HttpHeaders();
+    headers.add("mx-session-key", Session.current().getId());
+    return new ResponseEntity<>(response.getResult().wrapped(), createMultiMapForResponse(response.getHeaders(), headers), HttpStatus.OK);
   }
 
   @RequestMapping(value = "/reset_password/challenges/{challengeId}", method = RequestMethod.PUT, consumes = MDX_MEDIA)


### PR DESCRIPTION
# Summary of Changes

Creating a new session and deleting the old session when a user initiates the reset password flow

## Public API Additions/Changes

Going forward when a new request comes to the reset password flow a new session is established which we can use to recognize the user state in the reset password flow.

## Downstream Consumer Impact

Should not have any downstream impact on this

# How Has This Been Tested?

Verified that a new session is getting created and deleted if any old is passed along using the local testing.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
