### PR TITLE
fix: fixing the status code for reset password challenges list

### DIFF
--- a/mdx-web/src/main/java/com/mx/path/model/mdx/web/controller/AuthenticationController.java
+++ b/mdx-web/src/main/java/com/mx/path/model/mdx/web/controller/AuthenticationController.java
@@ -190,8 +190,8 @@ public class AuthenticationController extends BaseController {
     ResetPassword result = response.getResult();
     // Return 202 returning challenge questions
     HttpStatus status = HttpStatus.NO_CONTENT;
-    if (result.getChallenge() != null || response.getResult().getChallenges() != null
-        && response.getResult().getChallenges().size() > 0) {
+    if (result.getChallenge() != null || result.getChallenges() != null
+        && result.getChallenges().size() > 0) {
       status = HttpStatus.ACCEPTED;
     }
     return new ResponseEntity<>(result.wrapped(), createMultiMapForResponse(response.getHeaders()), status);

--- a/mdx-web/src/main/java/com/mx/path/model/mdx/web/controller/AuthenticationController.java
+++ b/mdx-web/src/main/java/com/mx/path/model/mdx/web/controller/AuthenticationController.java
@@ -190,7 +190,8 @@ public class AuthenticationController extends BaseController {
     ResetPassword result = response.getResult();
     // Return 202 returning challenge questions
     HttpStatus status = HttpStatus.NO_CONTENT;
-    if (result.getChallenge() != null) {
+    if (result.getChallenge() != null || response.getResult().getChallenges() != null
+        && response.getResult().getChallenges().size() > 0) {
       status = HttpStatus.ACCEPTED;
     }
     return new ResponseEntity<>(result.wrapped(), createMultiMapForResponse(response.getHeaders()), status);


### PR DESCRIPTION
# Summary of Changes

Currently we are not allowing to send list of challenges response for reset password. This will allow to now send those rather than a single challenge

Fixes # (issue)
Fixes the response for reset password mfa challenges

## Public API Additions/Changes

Please include a description of any new or modified publicly available classes and/or methods (if applicable).

## Downstream Consumer Impact

This is fix which was not previously done properly so no impact for the down stream system

# How Has This Been Tested?

This has been tested in my local to see that we will able to send the list of challenges

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
