### PR TITLE
Added support for document delivery preferences

### DIFF
--- a/mdx-models/src/main/java/com/mx/path/model/mdx/accessor/document/DocumentBaseAccessor.java
+++ b/mdx-models/src/main/java/com/mx/path/model/mdx/accessor/document/DocumentBaseAccessor.java
@@ -8,6 +8,7 @@ import com.mx.path.gateway.accessor.Accessor;
 import com.mx.path.gateway.accessor.AccessorConfiguration;
 import com.mx.path.gateway.accessor.AccessorResponse;
 import com.mx.path.model.mdx.model.MdxList;
+import com.mx.path.model.mdx.model.documents.DeliveryPreferences;
 import com.mx.path.model.mdx.model.documents.Document;
 import com.mx.path.model.mdx.model.documents.DocumentSearch;
 
@@ -55,4 +56,27 @@ public abstract class DocumentBaseAccessor extends Accessor {
     throw new AccessorMethodNotImplementedException();
   }
 
+  /**
+   * Get delivery preferences
+   *
+   * @param deliveryPreferences
+   * @return
+   */
+  @GatewayAPI
+  @API(description = "Get the current delivery preferences")
+  public AccessorResponse<DeliveryPreferences> deliveryPreferences(DeliveryPreferences deliveryPreferences) {
+    throw new AccessorMethodNotImplementedException();
+  }
+
+  /**
+   * Update delivery preferences
+   *
+   * @param deliveryPreferences
+   * @return
+   */
+  @GatewayAPI
+  @API(description = "Update the delivery preferences")
+  public AccessorResponse<Void> updateDeliveryPreferences(DeliveryPreferences deliveryPreferences) {
+    throw new AccessorMethodNotImplementedException();
+  }
 }

--- a/mdx-models/src/main/java/com/mx/path/model/mdx/accessor/document/DocumentBaseAccessor.java
+++ b/mdx-models/src/main/java/com/mx/path/model/mdx/accessor/document/DocumentBaseAccessor.java
@@ -76,7 +76,7 @@ public abstract class DocumentBaseAccessor extends Accessor {
    */
   @GatewayAPI
   @API(description = "Update the delivery preferences")
-  public AccessorResponse<Void> updateDeliveryPreferences(DeliveryPreferences deliveryPreferences) {
+  public AccessorResponse<DeliveryPreferences> updateDeliveryPreferences(DeliveryPreferences deliveryPreferences) {
     throw new AccessorMethodNotImplementedException();
   }
 }

--- a/mdx-models/src/main/java/com/mx/path/model/mdx/model/Resources.java
+++ b/mdx-models/src/main/java/com/mx/path/model/mdx/model/Resources.java
@@ -31,6 +31,7 @@ import com.mx.path.model.mdx.model.cross_account_transfer.CrossAccountTransfer;
 import com.mx.path.model.mdx.model.cross_account_transfer.DestinationAccount;
 import com.mx.path.model.mdx.model.dispute.Dispute;
 import com.mx.path.model.mdx.model.dispute.DisputedTransaction;
+import com.mx.path.model.mdx.model.documents.DeliveryPreferences;
 import com.mx.path.model.mdx.model.documents.Document;
 import com.mx.path.model.mdx.model.id.Authentication;
 import com.mx.path.model.mdx.model.id.ForgotUsername;
@@ -367,6 +368,8 @@ public class Resources {
     builder.registerTypeAdapter(RecurringPayment.class, new ModelWrappableSerializer("recurring_payment"));
     builder.registerTypeAdapter(new TypeToken<MdxList<RecurringPayment>>() {
     }.getType(), new ModelWrappableSerializer("recurring_payments"));
+    // Documents
+    builder.registerTypeAdapter(DeliveryPreferences.class, new ModelWrappableSerializer("delivery_preferences"));
   }
 
   private static void registerMultistageTransferModels(GsonBuilder builder) {

--- a/mdx-models/src/main/java/com/mx/path/model/mdx/model/documents/DeliveryPreferences.java
+++ b/mdx-models/src/main/java/com/mx/path/model/mdx/model/documents/DeliveryPreferences.java
@@ -1,0 +1,36 @@
+package com.mx.path.model.mdx.model.documents;
+
+import java.util.List;
+
+import com.mx.path.model.mdx.model.MdxBase;
+import com.mx.path.model.mdx.model.challenges.Challenge;
+
+public final class DeliveryPreferences extends MdxBase<DeliveryPreferences> {
+  private String accountId;
+  private List<Challenge> challenges;
+  private String documentType;
+
+  public String getAccountId() {
+    return accountId;
+  }
+
+  public void setAccountId(String accountId) {
+    this.accountId = accountId;
+  }
+
+  public List<Challenge> getChallenges() {
+    return challenges;
+  }
+
+  public void setChallenges(List<Challenge> challenges) {
+    this.challenges = challenges;
+  }
+
+  public String getDocumentType() {
+    return documentType;
+  }
+
+  public void setDocumentType(String documentType) {
+    this.documentType = documentType;
+  }
+}

--- a/mdx-web/src/main/java/com/mx/path/model/mdx/web/controller/DocumentsController.java
+++ b/mdx-web/src/main/java/com/mx/path/model/mdx/web/controller/DocumentsController.java
@@ -44,8 +44,8 @@ public class DocumentsController extends BaseController {
   }
 
   @RequestMapping(value = "/users/{userId}/documents/delivery_preferences", method = RequestMethod.PUT)
-  public final ResponseEntity<?> updateDeliveryPreferences(@RequestBody DeliveryPreferences deliveryPreferences) {
-    AccessorResponse<Void> response = gateway().documents().updateDeliveryPreferences(deliveryPreferences);
-    return new ResponseEntity<>(createMultiMapForResponse(response.getHeaders()), HttpStatus.NO_CONTENT);
+  public final ResponseEntity<DeliveryPreferences> updateDeliveryPreferences(@RequestBody DeliveryPreferences deliveryPreferences) {
+    AccessorResponse<DeliveryPreferences> response = gateway().documents().updateDeliveryPreferences(deliveryPreferences);
+    return new ResponseEntity<>(response.getResult().wrapped(), createMultiMapForResponse(response.getHeaders()), HttpStatus.ACCEPTED);
   }
 }

--- a/mdx-web/src/main/java/com/mx/path/model/mdx/web/controller/DocumentsController.java
+++ b/mdx-web/src/main/java/com/mx/path/model/mdx/web/controller/DocumentsController.java
@@ -2,12 +2,15 @@ package com.mx.path.model.mdx.web.controller;
 
 import com.mx.path.gateway.accessor.AccessorResponse;
 import com.mx.path.model.mdx.model.MdxList;
+import com.mx.path.model.mdx.model.documents.DeliveryPreferences;
 import com.mx.path.model.mdx.model.documents.Document;
 import com.mx.path.model.mdx.model.documents.DocumentSearch;
+import com.mx.path.model.mdx.web.model.document.DocumentDeliveryGetQueryParameters;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
@@ -29,5 +32,20 @@ public class DocumentsController extends BaseController {
   public final ResponseEntity<Document> getDocument(@PathVariable("id") String id) {
     AccessorResponse<Document> response = gateway().documents().get(id);
     return new ResponseEntity<>(response.getResult().wrapped(), createMultiMapForResponse(response.getHeaders()), HttpStatus.OK);
+  }
+
+  @RequestMapping(value = "/users/{userId}/documents/delivery_preferences", method = RequestMethod.GET)
+  public final ResponseEntity<DeliveryPreferences> getDeliveryPreferences(DocumentDeliveryGetQueryParameters queryParameters) {
+    DeliveryPreferences deliveryPreferences = new DeliveryPreferences();
+    deliveryPreferences.setAccountId(queryParameters.getAccount_id());
+    deliveryPreferences.setDocumentType(queryParameters.getDocument_type());
+    AccessorResponse<DeliveryPreferences> response = gateway().documents().deliveryPreferences(deliveryPreferences);
+    return new ResponseEntity<>(response.getResult().wrapped(), createMultiMapForResponse(response.getHeaders()), HttpStatus.ACCEPTED);
+  }
+
+  @RequestMapping(value = "/users/{userId}/documents/delivery_preferences", method = RequestMethod.PUT)
+  public final ResponseEntity<?> updateDeliveryPreferences(@RequestBody DeliveryPreferences deliveryPreferences) {
+    AccessorResponse<Void> response = gateway().documents().updateDeliveryPreferences(deliveryPreferences);
+    return new ResponseEntity<>(createMultiMapForResponse(response.getHeaders()), HttpStatus.NO_CONTENT);
   }
 }

--- a/mdx-web/src/main/java/com/mx/path/model/mdx/web/model/document/DocumentDeliveryGetQueryParameters.java
+++ b/mdx-web/src/main/java/com/mx/path/model/mdx/web/model/document/DocumentDeliveryGetQueryParameters.java
@@ -1,0 +1,12 @@
+package com.mx.path.model.mdx.web.model.document;
+
+import lombok.Data;
+
+@SuppressWarnings({ "checkstyle:MemberName", "checkstyle:ParameterName", "checkstyle:MethodName" })
+@Data
+public class DocumentDeliveryGetQueryParameters {
+
+  // NOTE: Non-standard naming to assist with parameter binding
+  private String account_id;
+  private String document_type;
+}

--- a/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/DocumentsControllerTest.groovy
+++ b/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/DocumentsControllerTest.groovy
@@ -1,5 +1,6 @@
 package com.mx.path.model.mdx.web.controller
 
+import static org.mockito.ArgumentMatchers.any
 import static org.mockito.Mockito.spy
 import static org.mockito.Mockito.verify
 
@@ -7,8 +8,10 @@ import com.mx.path.gateway.accessor.AccessorResponse
 import com.mx.path.gateway.api.Gateway
 import com.mx.path.gateway.api.document.DocumentGateway
 import com.mx.path.model.mdx.model.MdxList
+import com.mx.path.model.mdx.model.documents.DeliveryPreferences
 import com.mx.path.model.mdx.model.documents.Document
 import com.mx.path.model.mdx.model.documents.DocumentSearch
+import com.mx.path.model.mdx.web.model.document.DocumentDeliveryGetQueryParameters
 
 import org.mockito.Mockito
 import org.springframework.http.HttpStatus
@@ -60,5 +63,36 @@ class DocumentsControllerTest extends Specification {
     then:
     verify(documentGateway).list(documentSearch) || true
     HttpStatus.OK == response.getStatusCode()
+  }
+
+  def "getDeliveryPreferences interacts with gateway"() {
+    given:
+    BaseController.setGateway(gateway)
+
+    def queryParameters = new DocumentDeliveryGetQueryParameters()
+    def deliveryPreferences = new DeliveryPreferences()
+
+    when:
+    Mockito.doReturn(new AccessorResponse<DeliveryPreferences>().withResult(deliveryPreferences)).when(documentGateway).deliveryPreferences(any(DeliveryPreferences))
+    def response = subject.getDeliveryPreferences(queryParameters)
+
+    then:
+    verify(documentGateway).deliveryPreferences(any(DeliveryPreferences)) || true
+    HttpStatus.ACCEPTED == response.getStatusCode()
+  }
+
+  def "updateDeliveryPreferences interacts with gateway"() {
+    given:
+    BaseController.setGateway(gateway)
+
+    def deliveryPreferences = new DeliveryPreferences()
+
+    when:
+    Mockito.doReturn(new AccessorResponse<Void>()).when(documentGateway).updateDeliveryPreferences(deliveryPreferences)
+    def response = subject.updateDeliveryPreferences(deliveryPreferences)
+
+    then:
+    verify(documentGateway).updateDeliveryPreferences(deliveryPreferences) || true
+    HttpStatus.NO_CONTENT == response.getStatusCode()
   }
 }

--- a/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/DocumentsControllerTest.groovy
+++ b/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/DocumentsControllerTest.groovy
@@ -88,11 +88,11 @@ class DocumentsControllerTest extends Specification {
     def deliveryPreferences = new DeliveryPreferences()
 
     when:
-    Mockito.doReturn(new AccessorResponse<Void>()).when(documentGateway).updateDeliveryPreferences(deliveryPreferences)
+    Mockito.doReturn(new AccessorResponse<DeliveryPreferences>().withResult(deliveryPreferences)).when(documentGateway).updateDeliveryPreferences(deliveryPreferences)
     def response = subject.updateDeliveryPreferences(deliveryPreferences)
 
     then:
     verify(documentGateway).updateDeliveryPreferences(deliveryPreferences) || true
-    HttpStatus.NO_CONTENT == response.getStatusCode()
+    HttpStatus.ACCEPTED == response.getStatusCode()
   }
 }


### PR DESCRIPTION
# Summary of Changes

Added support for retrieving and updating document delivery preferences as per the updated spec:
https://developer.mx.com/drafts/mdx/documents/#documents-retrieve-delivery-preferences
https://developer.mx.com/drafts/mdx/documents/#documents-update-delivery-preferences

There are a couple FI's that are desiring this capability.

Fixes # IM-35 - Statement Delivery Preference Spec Change

## Public API Additions/Changes

Added the following methods to the DocumentBaseAccessor:

- deliveryPreferences - fetch document delivery preferences
- updateDeliveryPreferences - supports updating document delivery preferences

## Downstream Consumer Impact

There should be no impact to downstream consumers as the functionality is net new and pre-existing features, behavior and method signatures have not been touched.

# How Has This Been Tested?

The changes have been unit tested.  Also, I have published them locally and leveraged them in a DocumentAccessor implementation to confirm they provide the desired functionality and behave as expected.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
