### PR TITLE
Fix: adjust get account number route to match MDX spec

### DIFF
--- a/mdx-web/src/main/java/com/mx/path/model/mdx/web/controller/AccountNumbersController.java
+++ b/mdx-web/src/main/java/com/mx/path/model/mdx/web/controller/AccountNumbersController.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping(value = "{clientId}")
 public class AccountNumbersController extends BaseController {
-  @RequestMapping(value = "/accounts/{id}/account_numbers", method = RequestMethod.GET, produces = BaseController.MDX_ONDEMAND_MEDIA)
+  @RequestMapping(value = "/accounts/{id}/account_number", method = RequestMethod.GET, produces = BaseController.MDX_ONDEMAND_MEDIA)
   public final ResponseEntity<AccountNumbers> get(@PathVariable("id") String accountId) throws Exception {
     ensureFeature("accounts");
     AccessorResponse<AccountNumbers> response = gateway().accounts().accountNumbers().get(accountId);


### PR DESCRIPTION
# Summary of Changes

Fixes `Get Account Number` route to `/account_number` instead of `/account_numbers` per the MDX spec

Fixes #  [MC-1434](https://mxcom.atlassian.net/browse/MC-1434)

## Public API Additions/Changes

Fixes `Get Account Number` route

[MC-1434]: https://mxcom.atlassian.net/browse/MC-1434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

See spec https://developer.internal.mx/drafts/mdx/accounts/#accounts-retrieve-full-account-and-routing-numbers