### PR TITLE
feat: added support for unlocking user

### DIFF
--- a/mdx-models/src/main/java/com/mx/path/model/mdx/accessor/id/IdBaseAccessor.java
+++ b/mdx-models/src/main/java/com/mx/path/model/mdx/accessor/id/IdBaseAccessor.java
@@ -12,6 +12,7 @@ import com.mx.path.model.mdx.model.authorization.HtmlPage;
 import com.mx.path.model.mdx.model.id.Authentication;
 import com.mx.path.model.mdx.model.id.ForgotUsername;
 import com.mx.path.model.mdx.model.id.ResetPassword;
+import com.mx.path.model.mdx.model.id.UnlockUser;
 
 /**
  * Accessor for id operations
@@ -184,6 +185,17 @@ public abstract class IdBaseAccessor extends Accessor {
   @GatewayAPI
   @API(description = "Answer Reset Password")
   public AccessorResponse<ResetPassword> answerResetPassword(ResetPassword resetPassword) {
+    throw new AccessorMethodNotImplementedException();
+  }
+
+  /**
+   * Unlock user
+   *
+   * @return
+   */
+  @GatewayAPI
+  @API(description = "Unlock User")
+  public AccessorResponse<UnlockUser> unlockUser(UnlockUser unlockUser) {
     throw new AccessorMethodNotImplementedException();
   }
 }

--- a/mdx-models/src/main/java/com/mx/path/model/mdx/model/Resources.java
+++ b/mdx-models/src/main/java/com/mx/path/model/mdx/model/Resources.java
@@ -256,7 +256,7 @@ public class Resources {
     // ForgotUsername
     builder.registerTypeAdapter(ForgotUsername.class, new ModelWrappableSerializer("forgot_username"));
     // UnlockUser
-    builder.registerTypeAdapter(UnlockUser.class, new ModelWrappableSerializer("unlock"));
+    builder.registerTypeAdapter(UnlockUser.class, new ModelWrappableSerializer("unlock_user"));
     // Register Profile related models
     registerProfileModelClasses(builder);
     // Register ACH Transfer related models

--- a/mdx-models/src/main/java/com/mx/path/model/mdx/model/Resources.java
+++ b/mdx-models/src/main/java/com/mx/path/model/mdx/model/Resources.java
@@ -37,6 +37,7 @@ import com.mx.path.model.mdx.model.id.Authentication;
 import com.mx.path.model.mdx.model.id.ForgotUsername;
 import com.mx.path.model.mdx.model.id.MfaChallenge;
 import com.mx.path.model.mdx.model.id.ResetPassword;
+import com.mx.path.model.mdx.model.id.UnlockUser;
 import com.mx.path.model.mdx.model.location.Location;
 import com.mx.path.model.mdx.model.managed_cards.Destination;
 import com.mx.path.model.mdx.model.managed_cards.ManagedCard;
@@ -250,10 +251,12 @@ public class Resources {
     builder.registerTypeAdapter(MfaChallenge.class, new ModelWrappableSerializer("mfa_challenge"));
     builder.registerTypeAdapter(new TypeToken<MdxList<MfaChallenge>>() {
     }.getType(), new ModelWrappableSerializer("mfa_challenges"));
-    //ResetPassword
+    // ResetPassword
     builder.registerTypeAdapter(ResetPassword.class, new ModelWrappableSerializer("reset_password"));
-    //ForgotUsername
+    // ForgotUsername
     builder.registerTypeAdapter(ForgotUsername.class, new ModelWrappableSerializer("forgot_username"));
+    // UnlockUser
+    builder.registerTypeAdapter(UnlockUser.class, new ModelWrappableSerializer("unlock"));
     // Register Profile related models
     registerProfileModelClasses(builder);
     // Register ACH Transfer related models

--- a/mdx-models/src/main/java/com/mx/path/model/mdx/model/id/UnlockUser.java
+++ b/mdx-models/src/main/java/com/mx/path/model/mdx/model/id/UnlockUser.java
@@ -1,0 +1,18 @@
+package com.mx.path.model.mdx.model.id;
+
+import java.util.List;
+
+import com.mx.path.model.mdx.model.MdxBase;
+import com.mx.path.model.mdx.model.challenges.Challenge;
+
+public class UnlockUser extends MdxBase<UnlockUser> {
+  private List<Challenge> challenges;
+
+  public final List<Challenge> getChallenges() {
+    return challenges;
+  }
+
+  public final void setChallenges(List<Challenge> challenges) {
+    this.challenges = challenges;
+  }
+}

--- a/mdx-web/src/main/java/com/mx/path/model/mdx/web/controller/AuthenticationController.java
+++ b/mdx-web/src/main/java/com/mx/path/model/mdx/web/controller/AuthenticationController.java
@@ -16,6 +16,7 @@ import com.mx.path.model.mdx.model.authorization.HtmlPage;
 import com.mx.path.model.mdx.model.id.Authentication;
 import com.mx.path.model.mdx.model.id.ForgotUsername;
 import com.mx.path.model.mdx.model.id.ResetPassword;
+import com.mx.path.model.mdx.model.id.UnlockUser;
 
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -293,6 +294,31 @@ public class AuthenticationController extends BaseController {
     // Return 202 returning challenge questions
     HttpStatus status = HttpStatus.NO_CONTENT;
     if (result.getChallenge() != null) {
+      status = HttpStatus.ACCEPTED;
+    }
+    return new ResponseEntity<>(response.getResult().wrapped(), createMultiMapForResponse(response.getHeaders()), status);
+  }
+
+  @RequestMapping(value = "/unlock", method = RequestMethod.POST)
+  public final ResponseEntity<UnlockUser> unlockUser(@RequestBody UnlockUser unlockUser) {
+    //This endpoint always creates a new session when it called even if there is an existing session being passed
+    Session.deleteCurrent();
+    Session.createSession();
+
+    AccessorResponse<UnlockUser> response = gateway().id().unlockUser(unlockUser);
+
+    HttpHeaders headers = new HttpHeaders();
+    headers.add("mx-session-key", Session.current().getId());
+    return new ResponseEntity<>(response.getResult().wrapped(), createMultiMapForResponse(response.getHeaders(), headers), HttpStatus.ACCEPTED);
+  }
+
+  @RequestMapping(value = "/unlock", method = RequestMethod.PUT)
+  public final ResponseEntity<UnlockUser> answerUnlockUser(@RequestBody UnlockUser unlockUser) {
+    AccessorResponse<UnlockUser> response = gateway().id().unlockUser(unlockUser);
+    UnlockUser result = response.getResult();
+    // Return 202 returning challenge questions
+    HttpStatus status = HttpStatus.NO_CONTENT;
+    if (result.getChallenges() != null && result.getChallenges().size() > 0) {
       status = HttpStatus.ACCEPTED;
     }
     return new ResponseEntity<>(response.getResult().wrapped(), createMultiMapForResponse(response.getHeaders()), status);

--- a/mdx-web/src/main/java/com/mx/path/model/mdx/web/controller/AuthenticationController.java
+++ b/mdx-web/src/main/java/com/mx/path/model/mdx/web/controller/AuthenticationController.java
@@ -299,7 +299,7 @@ public class AuthenticationController extends BaseController {
     return new ResponseEntity<>(response.getResult().wrapped(), createMultiMapForResponse(response.getHeaders()), status);
   }
 
-  @RequestMapping(value = "/unlock", method = RequestMethod.POST)
+  @RequestMapping(value = "/unlock_user", method = RequestMethod.POST)
   public final ResponseEntity<UnlockUser> unlockUser(@RequestBody UnlockUser unlockUser) {
     //This endpoint always creates a new session when it called even if there is an existing session being passed
     Session.deleteCurrent();
@@ -312,7 +312,7 @@ public class AuthenticationController extends BaseController {
     return new ResponseEntity<>(response.getResult().wrapped(), createMultiMapForResponse(response.getHeaders(), headers), HttpStatus.ACCEPTED);
   }
 
-  @RequestMapping(value = "/unlock", method = RequestMethod.PUT)
+  @RequestMapping(value = "/unlock_user", method = RequestMethod.PUT)
   public final ResponseEntity<UnlockUser> answerUnlockUser(@RequestBody UnlockUser unlockUser) {
     AccessorResponse<UnlockUser> response = gateway().id().unlockUser(unlockUser);
     UnlockUser result = response.getResult();


### PR DESCRIPTION
# Summary of Changes

Added support for unlocking a user as per the [spec change](https://developer.mx.com/drafts/mdx/id/#authentications-unlock-user).

Fixes # HW-475

## Public API Additions/Changes

This includes two new methods to the AuthenticationController class:
- unlockUser - returns a challenge that must be responded to successfully in order to unlock the user.
- answerUnlockUser - receives the challenge response and performs the work to actually unlock the user.

## Downstream Consumer Impact

There should be minimal impact as this is newly introduced functionality in new methods.  No pre-existing methods have been modified.

# How Has This Been Tested?

I tested this by roughly implementing the IdAccessor.unlockUser method to ensure that I could receive and return the desired JSON and also to confirm that the appropriate status codes can be returned per each case.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
