### PR TITLE
feat: account alerts

### DIFF
--- a/mdx-models/src/main/java/com/mx/path/model/mdx/accessor/account/AccountAlertBaseAccessor.java
+++ b/mdx-models/src/main/java/com/mx/path/model/mdx/accessor/account/AccountAlertBaseAccessor.java
@@ -1,0 +1,121 @@
+package com.mx.path.model.mdx.accessor.account;
+
+import com.mx.path.core.common.accessor.API;
+import com.mx.path.core.common.accessor.AccessorMethodNotImplementedException;
+import com.mx.path.core.common.gateway.GatewayAPI;
+import com.mx.path.core.common.gateway.GatewayClass;
+import com.mx.path.gateway.accessor.Accessor;
+import com.mx.path.gateway.accessor.AccessorConfiguration;
+import com.mx.path.gateway.accessor.AccessorResponse;
+import com.mx.path.model.mdx.model.MdxList;
+import com.mx.path.model.mdx.model.account.Account;
+import com.mx.path.model.mdx.model.account.alerts.AccountAlert;
+import com.mx.path.model.mdx.model.account.alerts.DeliveryMethod;
+
+/**
+ * Accessor for account alert operations
+ */
+@GatewayClass
+@API(description = "Access to account alerts", specificationUrl = "https://developer.mx.com/drafts/mdx/accounts/#accounts-alerts")
+public abstract class AccountAlertBaseAccessor extends Accessor {
+
+  public AccountAlertBaseAccessor() {
+  }
+
+  /**
+   * @param configuration
+   * @deprecated Use the default constructor, the configuration is set by the accessor construction context code
+   */
+  @Deprecated
+  public AccountAlertBaseAccessor(AccessorConfiguration configuration) {
+    super(configuration);
+  }
+
+  /**
+   * Get an account alert
+   *
+   * @param accountId
+   * @param alertId
+   * @return
+   */
+  @GatewayAPI
+  @API(description = "Get account alert")
+  public AccessorResponse<AccountAlert> get(String accountId, String alertId) {
+    throw new AccessorMethodNotImplementedException();
+  }
+
+  /**
+   * List account alerts
+   *
+   * @param accountId
+   * @return
+   */
+  @GatewayAPI
+  @API(description = "List account alerts")
+  public AccessorResponse<MdxList<AccountAlert>> list(String accountId) {
+    throw new AccessorMethodNotImplementedException();
+  }
+
+  /**
+   * Create account alert
+   *
+   * @param accountId
+   * @param accountAlert
+   * @return
+   */
+  @GatewayAPI
+  @API(description = "Create account alert")
+  public AccessorResponse<AccountAlert> create(String accountId, AccountAlert accountAlert) {
+    throw new AccessorMethodNotImplementedException();
+  }
+
+  /**
+   * Update an account alert
+   *
+   * @param accountId
+   * @param accountAlert
+   * @return
+   */
+  @GatewayAPI
+  @API(description = "Update an account alert")
+  public AccessorResponse<AccountAlert> update(String accountId, AccountAlert accountAlert) {
+    throw new AccessorMethodNotImplementedException();
+  }
+
+  /**
+   * Delete an account alert by id
+   *
+   * @param accountId
+   * @param alertId
+   * @return
+   */
+  @GatewayAPI
+  @API(description = "Delete an account alert")
+  public AccessorResponse<Void> delete(String accountId, String alertId) {
+    throw new AccessorMethodNotImplementedException();
+  }
+
+  /**
+   * List delivery methods
+   *
+   * @param accountId
+   * @param alertId
+   * @return
+   */
+  @GatewayAPI
+  @API(description = "List delivery methods")
+  public AccessorResponse<MdxList<DeliveryMethod>> deliveryMethods(String accountId, String alertId) {
+    throw new AccessorMethodNotImplementedException();
+  }
+
+  /**
+   * List accounts eligible for alerts
+   *
+   * @return
+   */
+  @GatewayAPI
+  @API(description = "List accounts eligible for alerts")
+  public AccessorResponse<MdxList<Account>> accounts() {
+    throw new AccessorMethodNotImplementedException();
+  }
+}

--- a/mdx-models/src/main/java/com/mx/path/model/mdx/accessor/account/AccountBaseAccessor.java
+++ b/mdx-models/src/main/java/com/mx/path/model/mdx/accessor/account/AccountBaseAccessor.java
@@ -22,6 +22,10 @@ public abstract class AccountBaseAccessor extends Accessor {
 
   @GatewayAPI
   @Getter(AccessLevel.PROTECTED)
+  private AccountAlertBaseAccessor accountAlerts;
+
+  @GatewayAPI
+  @Getter(AccessLevel.PROTECTED)
   private AccountDetailsBaseAccessor accountDetails;
 
   @GatewayAPI
@@ -58,6 +62,20 @@ public abstract class AccountBaseAccessor extends Accessor {
   @Deprecated
   public AccountBaseAccessor(AccessorConfiguration configuration) {
     super(configuration);
+  }
+
+  /**
+   * Account alert accessor
+   *
+   * @return
+   */
+  @API(description = "Access account alerts")
+  public AccountAlertBaseAccessor accountAlerts() {
+    if (accountAlerts != null) {
+      return accountAlerts;
+    }
+
+    throw new AccessorMethodNotImplementedException();
   }
 
   /**
@@ -154,6 +172,15 @@ public abstract class AccountBaseAccessor extends Accessor {
     }
 
     throw new AccessorMethodNotImplementedException();
+  }
+
+  /**
+   * Set account alerts accessor
+   *
+   * @param accountAlerts
+   */
+  public void setAccountAlerts(AccountAlertBaseAccessor accountAlerts) {
+    this.accountAlerts = accountAlerts;
   }
 
   /**

--- a/mdx-models/src/main/java/com/mx/path/model/mdx/model/Resources.java
+++ b/mdx-models/src/main/java/com/mx/path/model/mdx/model/Resources.java
@@ -18,6 +18,8 @@ import com.mx.path.model.mdx.model.account.StopPayment;
 import com.mx.path.model.mdx.model.account.StopPaymentReason;
 import com.mx.path.model.mdx.model.account.Transaction;
 import com.mx.path.model.mdx.model.account.TransactionsPage;
+import com.mx.path.model.mdx.model.account.alerts.AccountAlert;
+import com.mx.path.model.mdx.model.account.alerts.DeliveryMethod;
 import com.mx.path.model.mdx.model.ach_transfer.AchAccount;
 import com.mx.path.model.mdx.model.ach_transfer.AchScheduledTransfer;
 import com.mx.path.model.mdx.model.ach_transfer.AchTransfer;
@@ -227,6 +229,8 @@ public class Resources {
     builder.registerTypeAdapter(Document.class, new ModelWrappableSerializer("document"));
     builder.registerTypeAdapter(new TypeToken<MdxList<Document>>() {
     }.getType(), new ModelWrappableSerializer("documents"));
+    // DeliveryPreferences
+    builder.registerTypeAdapter(DeliveryPreferences.class, new ModelWrappableSerializer("delivery_preferences"));
     // Location
     builder.registerTypeAdapter(Location.class, new ModelWrappableSerializer("location"));
     builder.registerTypeAdapter(new TypeToken<MdxList<Location>>() {
@@ -267,6 +271,8 @@ public class Resources {
     registerPaymentsModels(builder);
     // Register multistage transfer models
     registerMultistageTransferModels(builder);
+    // Register account alert models
+    registerAccountAlertModels(builder);
   }
 
   public static void registerOnDemandResources(SimpleModule module) {
@@ -382,8 +388,6 @@ public class Resources {
     builder.registerTypeAdapter(RecurringPayment.class, new ModelWrappableSerializer("recurring_payment"));
     builder.registerTypeAdapter(new TypeToken<MdxList<RecurringPayment>>() {
     }.getType(), new ModelWrappableSerializer("recurring_payments"));
-    // Documents
-    builder.registerTypeAdapter(DeliveryPreferences.class, new ModelWrappableSerializer("delivery_preferences"));
   }
 
   private static void registerMultistageTransferModels(GsonBuilder builder) {
@@ -395,5 +399,15 @@ public class Resources {
     builder.registerTypeAdapter(Repayment.class, new ModelWrappableSerializer("repayment"));
     builder.registerTypeAdapter(new TypeToken<MdxList<Repayment>>() {
     }.getType(), new ModelWrappableSerializer("repayments"));
+  }
+
+  private static void registerAccountAlertModels(GsonBuilder builder) {
+    // AccountAlert
+    builder.registerTypeAdapter(AccountAlert.class, new ModelWrappableSerializer("alert"));
+    builder.registerTypeAdapter(new TypeToken<MdxList<AccountAlert>>() {
+    }.getType(), new ModelWrappableSerializer("alerts"));
+    // DeliveryMethod
+    builder.registerTypeAdapter(new TypeToken<MdxList<DeliveryMethod>>() {
+    }.getType(), new ModelWrappableSerializer("delivery_methods"));
   }
 }

--- a/mdx-models/src/main/java/com/mx/path/model/mdx/model/account/alerts/AccountAlert.java
+++ b/mdx-models/src/main/java/com/mx/path/model/mdx/model/account/alerts/AccountAlert.java
@@ -1,0 +1,100 @@
+package com.mx.path.model.mdx.model.account.alerts;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import com.mx.path.model.mdx.model.MdxBase;
+import com.mx.path.model.mdx.model.challenges.Challenge;
+
+public class AccountAlert extends MdxBase<AccountAlert> {
+  private List<Challenge> challenges;
+  private Long createdAt;
+  private LocalDate createdOn;
+  private List<AlertCriteria> criteria;
+  private List<String> deliveryTargets;
+  private String description;
+  private String id;
+  private boolean isEnabled;
+  private String name;
+  private String type;
+
+  public final List<Challenge> getChallenges() {
+    return challenges;
+  }
+
+  public final void setChallenges(List<Challenge> challenges) {
+    this.challenges = challenges;
+  }
+
+  public final Long getCreatedAt() {
+    return createdAt;
+  }
+
+  public final void setCreatedAt(Long createdAt) {
+    this.createdAt = createdAt;
+  }
+
+  public final LocalDate getCreatedOn() {
+    return createdOn;
+  }
+
+  public final void setCreatedOn(LocalDate createdOn) {
+    this.createdOn = createdOn;
+  }
+
+  public final List<AlertCriteria> getCriteria() {
+    return criteria;
+  }
+
+  public final void setCriteria(List<AlertCriteria> criteria) {
+    this.criteria = criteria;
+  }
+
+  public final List<String> getDeliveryTargets() {
+    return deliveryTargets;
+  }
+
+  public final void setDeliveryTargets(List<String> deliveryTargets) {
+    this.deliveryTargets = deliveryTargets;
+  }
+
+  public final String getDescription() {
+    return description;
+  }
+
+  public final void setDescription(String description) {
+    this.description = description;
+  }
+
+  public final String getId() {
+    return id;
+  }
+
+  public final void setId(String id) {
+    this.id = id;
+  }
+
+  public final boolean isEnabled() {
+    return isEnabled;
+  }
+
+  public final void setEnabled(boolean enabled) {
+    isEnabled = enabled;
+  }
+
+  public final String getName() {
+    return name;
+  }
+
+  public final void setName(String name) {
+    this.name = name;
+  }
+
+  public final String getType() {
+    return type;
+  }
+
+  public final void setType(String type) {
+    this.type = type;
+  }
+}

--- a/mdx-models/src/main/java/com/mx/path/model/mdx/model/account/alerts/AlertCriteria.java
+++ b/mdx-models/src/main/java/com/mx/path/model/mdx/model/account/alerts/AlertCriteria.java
@@ -1,0 +1,33 @@
+package com.mx.path.model.mdx.model.account.alerts;
+
+import com.mx.path.model.mdx.model.MdxBase;
+
+public class AlertCriteria extends MdxBase<AlertCriteria> {
+  private String id;
+  private String name;
+  private String value;
+
+  public final String getId() {
+    return id;
+  }
+
+  public final void setId(String id) {
+    this.id = id;
+  }
+
+  public final String getName() {
+    return name;
+  }
+
+  public final void setName(String name) {
+    this.name = name;
+  }
+
+  public final String getValue() {
+    return value;
+  }
+
+  public final void setValue(String value) {
+    this.value = value;
+  }
+}

--- a/mdx-models/src/main/java/com/mx/path/model/mdx/model/account/alerts/DeliveryMethod.java
+++ b/mdx-models/src/main/java/com/mx/path/model/mdx/model/account/alerts/DeliveryMethod.java
@@ -1,0 +1,42 @@
+package com.mx.path.model.mdx.model.account.alerts;
+
+import com.mx.path.model.mdx.model.MdxBase;
+
+public class DeliveryMethod extends MdxBase<DeliveryMethod> {
+  private String channel;
+  private String description;
+  private boolean isEnabled;
+  private String target;
+
+  public final String getChannel() {
+    return channel;
+  }
+
+  public final void setChannel(String channel) {
+    this.channel = channel;
+  }
+
+  public final String getDescription() {
+    return description;
+  }
+
+  public final void setDescription(String description) {
+    this.description = description;
+  }
+
+  public final boolean isEnabled() {
+    return isEnabled;
+  }
+
+  public final void setEnabled(boolean enabled) {
+    isEnabled = enabled;
+  }
+
+  public final String getTarget() {
+    return target;
+  }
+
+  public final void setTarget(String target) {
+    this.target = target;
+  }
+}

--- a/mdx-web/src/main/java/com/mx/path/model/mdx/web/controller/AccountAlertsController.java
+++ b/mdx-web/src/main/java/com/mx/path/model/mdx/web/controller/AccountAlertsController.java
@@ -1,0 +1,68 @@
+package com.mx.path.model.mdx.web.controller;
+
+import com.mx.path.gateway.accessor.AccessorResponse;
+import com.mx.path.model.mdx.model.MdxList;
+import com.mx.path.model.mdx.model.account.Account;
+import com.mx.path.model.mdx.model.account.alerts.AccountAlert;
+import com.mx.path.model.mdx.model.account.alerts.DeliveryMethod;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping(value = "{clientId}")
+public class AccountAlertsController extends BaseController {
+  @RequestMapping(value = "/users/{userId}/accounts/{accountId}/alerts/{id}", method = RequestMethod.GET)
+  public final ResponseEntity<AccountAlert> getAlert(@PathVariable("accountId") String accountId, @PathVariable("id") String alertId) {
+    ensureFeature("accounts");
+    AccessorResponse<AccountAlert> response = gateway().accounts().accountAlerts().get(accountId, alertId);
+    return new ResponseEntity<>(response.getResult().wrapped(), createMultiMapForResponse(response.getHeaders()), HttpStatus.OK);
+  }
+
+  @RequestMapping(value = "/users/{userId}/accounts/{accountId}/alerts", method = RequestMethod.GET, produces = BaseController.MDX_MEDIA)
+  public final ResponseEntity<MdxList<AccountAlert>> getAlertList(@PathVariable("accountId") String accountId) {
+    ensureFeature("accounts");
+    AccessorResponse<MdxList<AccountAlert>> response = gateway().accounts().accountAlerts().list(accountId);
+    return new ResponseEntity<>(response.getResult().wrapped(), createMultiMapForResponse(response.getHeaders()), HttpStatus.OK);
+  }
+
+  @RequestMapping(value = "/users/{userId}/accounts/{accountId}/alerts", method = RequestMethod.POST, consumes = BaseController.MDX_MEDIA)
+  public final ResponseEntity<AccountAlert> createAlert(@PathVariable("accountId") String accountId, @RequestBody AccountAlert accountAlert) {
+    ensureFeature("accounts");
+    AccessorResponse<AccountAlert> response = gateway().accounts().accountAlerts().create(accountId, accountAlert);
+    return new ResponseEntity<>(response.getResult().wrapped(), createMultiMapForResponse(response.getHeaders()), HttpStatus.OK);
+  }
+
+  @RequestMapping(value = "/users/{userId}/accounts/{accountId}/alerts/{id}", method = RequestMethod.PUT, consumes = BaseController.MDX_MEDIA)
+  public final ResponseEntity<AccountAlert> updateAlert(@PathVariable("accountId") String accountId, @RequestBody AccountAlert accountAlert) {
+    ensureFeature("accounts");
+    AccessorResponse<AccountAlert> response = gateway().accounts().accountAlerts().update(accountId, accountAlert);
+    return new ResponseEntity<>(response.getResult().wrapped(), createMultiMapForResponse(response.getHeaders()), HttpStatus.OK);
+  }
+
+  @RequestMapping(value = "/users/{userId}/accounts/{accountId}/alerts/{id}", method = RequestMethod.DELETE)
+  public final ResponseEntity<?> deleteAlert(@PathVariable("accountId") String accountId, @PathVariable("id") String alertId) {
+    ensureFeature("accounts");
+    AccessorResponse<Void> response = gateway().accounts().accountAlerts().delete(accountId, alertId);
+    return new ResponseEntity<>(createMultiMapForResponse(response.getHeaders()), HttpStatus.NO_CONTENT);
+  }
+
+  @RequestMapping(value = "/users/{userId}/accounts/{accountId}/alerts/{id}/delivery_methods", method = RequestMethod.GET, produces = BaseController.MDX_MEDIA)
+  public final ResponseEntity<MdxList<DeliveryMethod>> getDeliveryMethods(@PathVariable("accountId") String accountId, @PathVariable("id") String alertId) {
+    ensureFeature("accounts");
+    AccessorResponse<MdxList<DeliveryMethod>> response = gateway().accounts().accountAlerts().deliveryMethods(accountId, alertId);
+    return new ResponseEntity<>(response.getResult().wrapped(), createMultiMapForResponse(response.getHeaders()), HttpStatus.OK);
+  }
+
+  @RequestMapping(value = "/users/{userId}/accounts/alert", method = RequestMethod.GET, produces = BaseController.MDX_MEDIA)
+  public final ResponseEntity<MdxList<Account>> getAccounts() {
+    ensureFeature("accounts");
+    AccessorResponse<MdxList<Account>> response = gateway().accounts().accountAlerts().accounts();
+    return new ResponseEntity<>(response.getResult().wrapped(), createMultiMapForResponse(response.getHeaders()), HttpStatus.OK);
+  }
+}

--- a/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/AccountAlertsControllerTest.groovy
+++ b/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/AccountAlertsControllerTest.groovy
@@ -1,0 +1,143 @@
+package com.mx.path.model.mdx.web.controller
+
+import static org.mockito.Mockito.doReturn
+import static org.mockito.Mockito.spy
+import static org.mockito.Mockito.verify
+
+import com.mx.path.gateway.accessor.AccessorResponse
+import com.mx.path.gateway.api.Gateway
+import com.mx.path.gateway.api.account.AccountAlertGateway
+import com.mx.path.gateway.api.account.AccountGateway
+import com.mx.path.model.mdx.model.MdxList
+import com.mx.path.model.mdx.model.account.Account
+import com.mx.path.model.mdx.model.account.alerts.AccountAlert
+import com.mx.path.model.mdx.model.account.alerts.DeliveryMethod
+
+import org.springframework.http.HttpStatus
+
+import spock.lang.Specification
+
+class AccountAlertsControllerTest extends Specification {
+  AccountAlertsController subject
+  Gateway gateway
+  AccountAlertGateway accountAlertGateway
+
+  void setup() {
+    subject = new AccountAlertsController()
+    accountAlertGateway = spy(AccountAlertGateway.builder().build())
+
+    gateway = Gateway.builder()
+        .accounts(AccountGateway.builder()
+        .accountAlerts(accountAlertGateway)
+        .build())
+        .build()
+
+    BaseController.setGateway(gateway)
+  }
+
+  def cleanup() {
+    BaseController.clearGateway()
+  }
+
+  def "getAlert interacts with gateway"() {
+    given:
+    def accountId = "account-id"
+    def alertId = "alert-id"
+    def accountAlert = new AccountAlert()
+
+    when:
+    doReturn(new AccessorResponse<AccountAlert>().withResult(accountAlert)).when(accountAlertGateway).get(accountId, alertId)
+    def response = subject.getAlert(accountId, alertId)
+
+    then:
+    verify(accountAlertGateway).get(accountId, alertId) || true
+    response.body == accountAlert
+  }
+
+  def "getAlertList interacts with gateway"() {
+    given:
+    def accountId = "account-id"
+    def alerts = new MdxList<AccountAlert>()
+    alerts.add(new AccountAlert())
+
+    when:
+    doReturn(new AccessorResponse<MdxList<AccountAlert>>().withResult(alerts)).when(accountAlertGateway).list(accountId)
+    def response = subject.getAlertList(accountId)
+
+    then:
+    verify(accountAlertGateway).list(accountId) || true
+    response.body == alerts
+  }
+
+  def "createAlert interacts with gateway"() {
+    given:
+    def accountId = "account-id"
+    def accountAlert = new AccountAlert()
+
+    when:
+    doReturn(new AccessorResponse<AccountAlert>().withResult(accountAlert)).when(accountAlertGateway).create(accountId, accountAlert)
+    def response = subject.createAlert(accountId, accountAlert)
+
+    then:
+    verify(accountAlertGateway).create(accountId, accountAlert) || true
+    response.body == accountAlert
+  }
+
+  def "updateAlert interacts with gateway"() {
+    given:
+    def accountId = "account-id"
+    def accountAlert = new AccountAlert()
+
+    when:
+    doReturn(new AccessorResponse<AccountAlert>().withResult(accountAlert)).when(accountAlertGateway).update(accountId, accountAlert)
+    def response = subject.updateAlert(accountId, accountAlert)
+
+    then:
+    verify(accountAlertGateway).update(accountId, accountAlert) || true
+    response.body == accountAlert
+  }
+
+  def "deleteAlert interacts with gateway"() {
+    given:
+    def accountId = "account-id"
+    def alertId = "alert-id"
+
+    when:
+    doReturn(new AccessorResponse<Void>()).when(accountAlertGateway).delete(accountId, alertId)
+    def response = subject.deleteAlert(accountId, alertId)
+
+    then:
+    verify(accountAlertGateway).delete(accountId, alertId) || true
+    HttpStatus.NO_CONTENT == response.statusCode
+  }
+
+  def "getDeliveryMethods interacts with gateway"() {
+    given:
+    def accountId = "account-id"
+    def alertId = "alert-id"
+    def deliveryMethods = new MdxList<DeliveryMethod>()
+    deliveryMethods.add(new DeliveryMethod())
+
+    when:
+    doReturn(new AccessorResponse<MdxList<DeliveryMethod>>().withResult(deliveryMethods)).when(accountAlertGateway).deliveryMethods(accountId, alertId)
+    def response = subject.getDeliveryMethods(accountId, alertId)
+
+    then:
+    verify(accountAlertGateway).deliveryMethods(accountId, alertId) || true
+    response.body == deliveryMethods
+  }
+
+  def "getAccounts interacts with gateway"() {
+    given:
+    def accounts = new MdxList<Account>()
+    accounts.add(new Account())
+
+    when:
+    doReturn(new AccessorResponse<MdxList<Account>>().withResult(accounts)).when(accountAlertGateway).accounts()
+    def response = subject.getAccounts()
+
+    then:
+    verify(accountAlertGateway).accounts() || true
+    response.body == accounts
+  }
+}


### PR DESCRIPTION
# Summary of Changes

Added support for account alerts, which is a feature that has been requested by a customer.

Fixes #HW2-405

## Public API Additions/Changes

See the [corresponding documentation here](https://developer.mx.com/drafts/mdx/accounts/#accounts-alerts-retrieve-an-alert).

- GET /users/{userId}/accounts/{accountId}/alerts/{id} - Get an account alert by ID
- GET /users/{userId}/accounts/{accountId}/alerts - Retrieve a list of account alerts
- POST /users/{userId}/accounts/{accountId}/alerts - Create an account alert
- PUT /users/{userId}/accounts/{accountId}/alerts/{id} - Update an account alert
- DELETE /users/{userId}/accounts/{accountId}/alerts/{id} - Delete an account alert
- GET /users/{userId}/accounts/{accountId}/alerts/{id}/delivery_methods - Retrieve a list of account alert delivery methods
- GET /users/{userId}/accounts/alert - Retrieve a list of accounts eligible for alerts

## Downstream Consumer Impact

There should be no breaking changes as these are new endpoints.

# How Has This Been Tested?

I roughly implemented the `AccountAlertAccessor` to validate that the desired response status code and JSON is produced for each API function.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
