### PR TITLE
feat: add default logout implementation

### DIFF
--- a/mdx-models/src/main/java/com/mx/path/model/mdx/accessor/id/IdBaseAccessor.java
+++ b/mdx-models/src/main/java/com/mx/path/model/mdx/accessor/id/IdBaseAccessor.java
@@ -2,6 +2,7 @@ package com.mx.path.model.mdx.accessor.id;
 
 import com.mx.path.core.common.accessor.API;
 import com.mx.path.core.common.accessor.AccessorMethodNotImplementedException;
+import com.mx.path.core.common.accessor.PathResponseStatus;
 import com.mx.path.core.common.gateway.GatewayAPI;
 import com.mx.path.core.common.gateway.GatewayClass;
 import com.mx.path.core.common.remote.RemoteOperation;
@@ -98,11 +99,13 @@ public abstract class IdBaseAccessor extends Accessor {
 
   /**
    * End current session
+   *
+   * <p>Default implementation does nothing and returns a 204
    */
   @GatewayAPI
   @API(description = "Terminate the session")
   public AccessorResponse<Void> logout(String sessionId) {
-    throw new AccessorMethodNotImplementedException();
+    return AccessorResponse.<Void>builder().status(PathResponseStatus.NO_CONTENT).build();
   }
 
   /**

--- a/mdx-models/src/test/groovy/com/mx/path/model/mdx/accessor/id/IdBaseAccessorTest.groovy
+++ b/mdx-models/src/test/groovy/com/mx/path/model/mdx/accessor/id/IdBaseAccessorTest.groovy
@@ -1,0 +1,26 @@
+package com.mx.path.model.mdx.accessor.id
+
+import com.mx.path.core.common.accessor.PathResponseStatus
+
+import spock.lang.Specification
+
+class IdBaseAccessorTest extends Specification {
+  def subject
+
+  def setup() {
+    subject = new TestAccessor()
+  }
+
+  class TestAccessor extends IdBaseAccessor {
+    TestAccessor() {
+      super(null)
+    }
+  }
+
+  def "test logout"() {
+    when:
+    def response = subject.logout(null)
+    then:
+    response.status == PathResponseStatus.NO_CONTENT
+  }
+}


### PR DESCRIPTION
# Summary of Changes

This adds a default implementation for logout. This will fix errors resulting in calling logout when the accessor does not have an implementation.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
