### PR TITLE
feat: remove references to UserIdProvider and mark deprecated

### DIFF
--- a/mdx-models/src/main/java/com/mx/path/model/mdx/model/MdxBase.java
+++ b/mdx-models/src/main/java/com/mx/path/model/mdx/model/MdxBase.java
@@ -5,11 +5,18 @@ import java.util.List;
 
 import com.mx.path.core.common.model.ModelBase;
 import com.mx.path.core.common.model.Warning;
+import com.mx.path.core.context.Session;
 
 public abstract class MdxBase<T> extends ModelBase<T> {
   private String userId;
 
   private List<Warning> warnings;
+
+  public MdxBase() {
+    if (Session.current() != null) {
+      this.setUserId(Session.current().getUserId());
+    }
+  }
 
   public final String getUserId() {
     return this.userId;

--- a/mdx-models/src/main/java/com/mx/path/model/mdx/model/MdxBase.java
+++ b/mdx-models/src/main/java/com/mx/path/model/mdx/model/MdxBase.java
@@ -3,6 +3,7 @@ package com.mx.path.model.mdx.model;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.mx.path.core.common.lang.Strings;
 import com.mx.path.core.common.model.ModelBase;
 import com.mx.path.core.common.model.Warning;
 import com.mx.path.core.context.Session;
@@ -13,7 +14,7 @@ public abstract class MdxBase<T> extends ModelBase<T> {
   private List<Warning> warnings;
 
   public MdxBase() {
-    if (Session.current() != null) {
+    if (Session.current() != null && Strings.isNotBlank(Session.current().getUserId())) {
       this.setUserId(Session.current().getUserId());
     }
   }

--- a/mdx-models/src/main/java/com/mx/path/model/mdx/model/UserIdProvider.java
+++ b/mdx-models/src/main/java/com/mx/path/model/mdx/model/UserIdProvider.java
@@ -7,7 +7,10 @@ import com.mx.path.core.context.Session;
  * <p>
  * This static class uses the current session to the current user's id and put it on provided objects.
  * This provider is called in the constructor of Mdx Models that need a user id.
+ *
+ * @deprecated Use {@link Session} instead. This class will be removed in a future release.
  */
+@Deprecated
 public class UserIdProvider {
   public static void setUserId(MdxBase<?> obj) {
     if (Session.current() != null) {

--- a/mdx-models/src/main/java/com/mx/path/model/mdx/model/account/Account.java
+++ b/mdx-models/src/main/java/com/mx/path/model/mdx/model/account/Account.java
@@ -9,7 +9,6 @@ import com.google.gson.annotations.SerializedName;
 import com.mx.path.core.common.model.Internal;
 import com.mx.path.model.mdx.model.MdxBase;
 import com.mx.path.model.mdx.model.MdxList;
-import com.mx.path.model.mdx.model.UserIdProvider;
 import com.mx.path.model.mdx.model.challenges.Challenge;
 
 @SuppressWarnings("PMD.CyclomaticComplexity")
@@ -155,10 +154,6 @@ public class Account extends MdxBase<Account> {
   @Internal
   @SerializedName("transfer_to")
   private boolean transferTo;
-
-  public Account() {
-    UserIdProvider.setUserId(this);
-  }
 
   public final BigDecimal getAvailableBalance() {
     return availableBalance;

--- a/mdx-models/src/main/java/com/mx/path/model/mdx/model/account/Transaction.java
+++ b/mdx-models/src/main/java/com/mx/path/model/mdx/model/account/Transaction.java
@@ -6,7 +6,6 @@ import java.time.LocalDate;
 import javax.xml.bind.annotation.XmlElement;
 
 import com.mx.path.model.mdx.model.MdxBase;
-import com.mx.path.model.mdx.model.UserIdProvider;
 
 /**
  * Represents an MDX transaction. XmlElements assigned so that it can be demarshalled from MDXv5 XML.
@@ -67,10 +66,6 @@ public class Transaction extends MdxBase<Transaction> {
   private String type;
   @XmlElement(name = "user_guid")
   private String userGuid;
-
-  public Transaction() {
-    UserIdProvider.setUserId(this);
-  }
 
   public final String getAccountGuid() {
     return accountGuid;

--- a/mdx-models/src/main/java/com/mx/path/model/mdx/model/cross_account_transfer/CrossAccountRecurringTransfer.java
+++ b/mdx-models/src/main/java/com/mx/path/model/mdx/model/cross_account_transfer/CrossAccountRecurringTransfer.java
@@ -8,7 +8,6 @@ import lombok.Getter;
 
 import com.mx.path.model.mdx.model.MdxBase;
 import com.mx.path.model.mdx.model.MdxRelationId;
-import com.mx.path.model.mdx.model.UserIdProvider;
 import com.mx.path.model.mdx.model.account.Account;
 
 @EqualsAndHashCode(callSuper = true)
@@ -31,8 +30,4 @@ public class CrossAccountRecurringTransfer extends MdxBase<CrossAccountRecurring
   private LocalDate nextTransferOn;
   private String status;
   private LocalDate startOn;
-
-  public CrossAccountRecurringTransfer() {
-    UserIdProvider.setUserId(this);
-  }
 }

--- a/mdx-models/src/main/java/com/mx/path/model/mdx/model/cross_account_transfer/CrossAccountTransfer.java
+++ b/mdx-models/src/main/java/com/mx/path/model/mdx/model/cross_account_transfer/CrossAccountTransfer.java
@@ -8,7 +8,6 @@ import lombok.Getter;
 
 import com.mx.path.model.mdx.model.MdxBase;
 import com.mx.path.model.mdx.model.MdxRelationId;
-import com.mx.path.model.mdx.model.UserIdProvider;
 import com.mx.path.model.mdx.model.account.Account;
 
 @EqualsAndHashCode(callSuper = true)
@@ -33,8 +32,4 @@ public final class CrossAccountTransfer extends MdxBase<CrossAccountTransfer> {
   private String status;
   @Deprecated
   private String toAccountNumber;
-
-  public CrossAccountTransfer() {
-    UserIdProvider.setUserId(this);
-  }
 }

--- a/mdx-models/src/main/java/com/mx/path/model/mdx/model/dispute/Dispute.java
+++ b/mdx-models/src/main/java/com/mx/path/model/mdx/model/dispute/Dispute.java
@@ -3,7 +3,6 @@ package com.mx.path.model.mdx.model.dispute;
 import javax.xml.bind.annotation.XmlElement;
 
 import com.mx.path.model.mdx.model.MdxBase;
-import com.mx.path.model.mdx.model.UserIdProvider;
 
 /**
  * Represents an MDX dispute. XmlElements assigned so that it can be demarshalled from MDXv5 XML.
@@ -64,10 +63,6 @@ public class Dispute extends MdxBase<Dispute> {
   private String sourceImage;
   @XmlElement(name = "status")
   private String status;
-
-  public Dispute() {
-    UserIdProvider.setUserId(this);
-  }
 
   public final String getAccountId() {
     return accountId;

--- a/mdx-models/src/main/java/com/mx/path/model/mdx/model/dispute/DisputedTransaction.java
+++ b/mdx-models/src/main/java/com/mx/path/model/mdx/model/dispute/DisputedTransaction.java
@@ -3,7 +3,6 @@ package com.mx.path.model.mdx.model.dispute;
 import javax.xml.bind.annotation.XmlElement;
 
 import com.mx.path.model.mdx.model.MdxBase;
-import com.mx.path.model.mdx.model.UserIdProvider;
 
 /**
  * Represents an MDX disputed transaction. XmlElements assigned so that it can be demarshalled from MDXv5 XML.
@@ -22,10 +21,6 @@ public class DisputedTransaction extends MdxBase<DisputedTransaction> {
   private String transactedOn;
   @XmlElement(name = "transaction_id")
   private String transactionId;
-
-  public DisputedTransaction() {
-    UserIdProvider.setUserId(this);
-  }
 
   public final Double getAmount() {
     return amount;

--- a/mdx-models/src/main/java/com/mx/path/model/mdx/model/documents/Document.java
+++ b/mdx-models/src/main/java/com/mx/path/model/mdx/model/documents/Document.java
@@ -3,7 +3,6 @@ package com.mx.path.model.mdx.model.documents;
 import java.time.LocalDate;
 
 import com.mx.path.model.mdx.model.MdxBase;
-import com.mx.path.model.mdx.model.UserIdProvider;
 
 /*
  Up to date with MDX Documents Rev 5
@@ -20,10 +19,6 @@ public final class Document extends MdxBase<Document> {
   private String id;
   private String name;
   private String type;
-
-  public Document() {
-    UserIdProvider.setUserId(this);
-  }
 
   public String getAccountId() {
     return accountId;

--- a/mdx-models/src/main/java/com/mx/path/model/mdx/model/managed_cards/ManagedCard.java
+++ b/mdx-models/src/main/java/com/mx/path/model/mdx/model/managed_cards/ManagedCard.java
@@ -5,7 +5,6 @@ import lombok.EqualsAndHashCode;
 import com.google.gson.annotations.SerializedName;
 import com.mx.path.core.common.model.Internal;
 import com.mx.path.model.mdx.model.MdxBase;
-import com.mx.path.model.mdx.model.UserIdProvider;
 import com.mx.path.model.mdx.model.challenges.Challenge;
 
 @EqualsAndHashCode
@@ -40,10 +39,6 @@ public final class ManagedCard extends MdxBase<ManagedCard> {
   @Internal
   @SerializedName("ondot_ref_id")
   private String ondotRefId;
-
-  public ManagedCard() {
-    UserIdProvider.setUserId(this);
-  }
 
   public String getAccountId() {
     return accountId;

--- a/mdx-models/src/main/java/com/mx/path/model/mdx/model/managed_cards/TravelSchedule.java
+++ b/mdx-models/src/main/java/com/mx/path/model/mdx/model/managed_cards/TravelSchedule.java
@@ -1,7 +1,6 @@
 package com.mx.path.model.mdx.model.managed_cards;
 
 import com.mx.path.model.mdx.model.MdxBase;
-import com.mx.path.model.mdx.model.UserIdProvider;
 
 public final class TravelSchedule extends MdxBase<TravelSchedule> {
 
@@ -14,10 +13,6 @@ public final class TravelSchedule extends MdxBase<TravelSchedule> {
   private String secondaryPhoneNumber;
   private String startOn;
   private String status;
-
-  public TravelSchedule() {
-    UserIdProvider.setUserId(this);
-  }
 
   public String[] getCardIds() {
     return cardIds;

--- a/mdx-models/src/main/java/com/mx/path/model/mdx/model/payment/Bill.java
+++ b/mdx-models/src/main/java/com/mx/path/model/mdx/model/payment/Bill.java
@@ -3,7 +3,6 @@ package com.mx.path.model.mdx.model.payment;
 import java.time.LocalDate;
 
 import com.mx.path.model.mdx.model.MdxBase;
-import com.mx.path.model.mdx.model.UserIdProvider;
 
 public final class Bill extends MdxBase<Bill> {
 
@@ -14,10 +13,6 @@ public final class Bill extends MdxBase<Bill> {
   private String payeeId;
   private LocalDate paymentDueOn;
   private String status;
-
-  public Bill() {
-    UserIdProvider.setUserId(this);
-  }
 
   public Double getAmount() {
     return amount;

--- a/mdx-models/src/main/java/com/mx/path/model/mdx/model/payment/Payee.java
+++ b/mdx-models/src/main/java/com/mx/path/model/mdx/model/payment/Payee.java
@@ -3,7 +3,6 @@ package com.mx.path.model.mdx.model.payment;
 import java.util.List;
 
 import com.mx.path.model.mdx.model.MdxBase;
-import com.mx.path.model.mdx.model.UserIdProvider;
 import com.mx.path.model.mdx.model.challenges.Challenge;
 
 public final class Payee extends MdxBase<Payee> {
@@ -24,10 +23,6 @@ public final class Payee extends MdxBase<Payee> {
   private String phoneNumber;
   private String postalCode;
   private String state;
-
-  public Payee() {
-    UserIdProvider.setUserId(this);
-  }
 
   public String getAccountNumber() {
     return accountNumber;

--- a/mdx-models/src/main/java/com/mx/path/model/mdx/model/payment/Payment.java
+++ b/mdx-models/src/main/java/com/mx/path/model/mdx/model/payment/Payment.java
@@ -3,7 +3,6 @@ package com.mx.path.model.mdx.model.payment;
 import java.time.LocalDate;
 
 import com.mx.path.model.mdx.model.MdxBase;
-import com.mx.path.model.mdx.model.UserIdProvider;
 
 public final class Payment extends MdxBase<Payment> {
 
@@ -22,10 +21,6 @@ public final class Payment extends MdxBase<Payment> {
   private Long sentAt;
   private String sentOn;
   private String status;
-
-  public Payment() {
-    UserIdProvider.setUserId(this);
-  }
 
   public String getAccountId() {
     return accountId;

--- a/mdx-models/src/main/java/com/mx/path/model/mdx/model/payment/RecurringPayment.java
+++ b/mdx-models/src/main/java/com/mx/path/model/mdx/model/payment/RecurringPayment.java
@@ -3,7 +3,6 @@ package com.mx.path.model.mdx.model.payment;
 import java.time.LocalDate;
 
 import com.mx.path.model.mdx.model.MdxBase;
-import com.mx.path.model.mdx.model.UserIdProvider;
 
 public final class RecurringPayment extends MdxBase<RecurringPayment> {
   private String id;
@@ -21,10 +20,6 @@ public final class RecurringPayment extends MdxBase<RecurringPayment> {
   private Long paymentsCount;
   private LocalDate nextPaymentOn;
   private LocalDate lastPaymentOn;
-
-  public RecurringPayment() {
-    UserIdProvider.setUserId(this);
-  }
 
   public String getId() {
     return id;

--- a/mdx-models/src/main/java/com/mx/path/model/mdx/model/payout/Challenge.java
+++ b/mdx-models/src/main/java/com/mx/path/model/mdx/model/payout/Challenge.java
@@ -1,17 +1,12 @@
 package com.mx.path.model.mdx.model.payout;
 
 import com.mx.path.model.mdx.model.MdxBase;
-import com.mx.path.model.mdx.model.UserIdProvider;
 
 public final class Challenge extends MdxBase<Challenge> {
 
   private String id;
   private String prompt;
   private Question[] questions;
-
-  public Challenge() {
-    UserIdProvider.setUserId(this);
-  }
 
   public String getId() {
     return id;

--- a/mdx-models/src/main/java/com/mx/path/model/mdx/model/payout/Payout.java
+++ b/mdx-models/src/main/java/com/mx/path/model/mdx/model/payout/Payout.java
@@ -3,7 +3,6 @@ package com.mx.path.model.mdx.model.payout;
 import java.time.LocalDate;
 
 import com.mx.path.model.mdx.model.MdxBase;
-import com.mx.path.model.mdx.model.UserIdProvider;
 
 public final class Payout extends MdxBase<Payout> {
 
@@ -30,10 +29,6 @@ public final class Payout extends MdxBase<Payout> {
   private String type;
   private String challengeQuestion;
   private String challengeAnswer;
-
-  public Payout() {
-    UserIdProvider.setUserId(this);
-  }
 
   public String getAccountId() {
     return accountId;

--- a/mdx-models/src/main/java/com/mx/path/model/mdx/model/payout/PayoutContactMethod.java
+++ b/mdx-models/src/main/java/com/mx/path/model/mdx/model/payout/PayoutContactMethod.java
@@ -1,7 +1,6 @@
 package com.mx.path.model.mdx.model.payout;
 
 import com.mx.path.model.mdx.model.MdxBase;
-import com.mx.path.model.mdx.model.UserIdProvider;
 
 public final class PayoutContactMethod extends MdxBase<PayoutContactMethod> {
 
@@ -10,10 +9,6 @@ public final class PayoutContactMethod extends MdxBase<PayoutContactMethod> {
   private String payoutContactMethodType;
   private String phoneNumber;
   private String status;
-
-  public PayoutContactMethod() {
-    UserIdProvider.setUserId(this);
-  }
 
   public String getEmailAddress() {
     return emailAddress;

--- a/mdx-models/src/main/java/com/mx/path/model/mdx/model/payout/PayoutMethod.java
+++ b/mdx-models/src/main/java/com/mx/path/model/mdx/model/payout/PayoutMethod.java
@@ -1,7 +1,6 @@
 package com.mx.path.model.mdx.model.payout;
 
 import com.mx.path.model.mdx.model.MdxBase;
-import com.mx.path.model.mdx.model.UserIdProvider;
 
 public final class PayoutMethod extends MdxBase<PayoutMethod> {
 
@@ -16,10 +15,6 @@ public final class PayoutMethod extends MdxBase<PayoutMethod> {
   private String routingNumber;
   private String sendTo;
   private String status;
-
-  public PayoutMethod() {
-    UserIdProvider.setUserId(this);
-  }
 
   public String getAccountNumber() {
     return accountNumber;

--- a/mdx-models/src/main/java/com/mx/path/model/mdx/model/payout/PayoutRequest.java
+++ b/mdx-models/src/main/java/com/mx/path/model/mdx/model/payout/PayoutRequest.java
@@ -3,7 +3,6 @@ package com.mx.path.model.mdx.model.payout;
 import java.time.LocalDate;
 
 import com.mx.path.model.mdx.model.MdxBase;
-import com.mx.path.model.mdx.model.UserIdProvider;
 
 public final class PayoutRequest extends MdxBase<PayoutRequest> {
   private String accountId;
@@ -17,10 +16,6 @@ public final class PayoutRequest extends MdxBase<PayoutRequest> {
   private String status;
   private LocalDate sentOn;
   private String type;
-
-  public PayoutRequest() {
-    UserIdProvider.setUserId(this);
-  }
 
   public String getAccountId() {
     return accountId;

--- a/mdx-models/src/main/java/com/mx/path/model/mdx/model/payout/PayoutSettings.java
+++ b/mdx-models/src/main/java/com/mx/path/model/mdx/model/payout/PayoutSettings.java
@@ -1,7 +1,6 @@
 package com.mx.path.model.mdx.model.payout;
 
 import com.mx.path.model.mdx.model.MdxBase;
-import com.mx.path.model.mdx.model.UserIdProvider;
 
 public final class PayoutSettings extends MdxBase<PayoutSettings> {
 
@@ -9,10 +8,6 @@ public final class PayoutSettings extends MdxBase<PayoutSettings> {
   private String emailAddress;
   private String payoutContactMethodType;
   private String status;
-
-  private PayoutSettings() {
-    UserIdProvider.setUserId(this);
-  }
 
   public String getId() {
     return id;

--- a/mdx-models/src/main/java/com/mx/path/model/mdx/model/payout/Recipient.java
+++ b/mdx-models/src/main/java/com/mx/path/model/mdx/model/payout/Recipient.java
@@ -2,7 +2,6 @@ package com.mx.path.model.mdx.model.payout;
 
 import com.mx.path.model.mdx.model.MdxBase;
 import com.mx.path.model.mdx.model.MdxList;
-import com.mx.path.model.mdx.model.UserIdProvider;
 
 public final class Recipient extends MdxBase<Recipient> {
 
@@ -11,10 +10,6 @@ public final class Recipient extends MdxBase<Recipient> {
   private String lastName;
   private String primaryPayoutMethodId;
   private MdxList<PayoutMethod> payoutMethods;
-
-  public Recipient() {
-    UserIdProvider.setUserId(this);
-  }
 
   public String getFirstName() {
     return firstName;

--- a/mdx-models/src/main/java/com/mx/path/model/mdx/model/payout/RecurringPayout.java
+++ b/mdx-models/src/main/java/com/mx/path/model/mdx/model/payout/RecurringPayout.java
@@ -1,7 +1,6 @@
 package com.mx.path.model.mdx.model.payout;
 
 import com.mx.path.model.mdx.model.MdxBase;
-import com.mx.path.model.mdx.model.UserIdProvider;
 
 public final class RecurringPayout extends MdxBase<RecurringPayout> {
 
@@ -21,10 +20,6 @@ public final class RecurringPayout extends MdxBase<RecurringPayout> {
   private String startOn;
   private String status;
   private String token;
-
-  public RecurringPayout() {
-    UserIdProvider.setUserId(this);
-  }
 
   public String getAccountId() {
     return accountId;

--- a/mdx-models/src/main/java/com/mx/path/model/mdx/model/remote_deposit/RemoteDeposit.java
+++ b/mdx-models/src/main/java/com/mx/path/model/mdx/model/remote_deposit/RemoteDeposit.java
@@ -5,7 +5,6 @@ import java.time.LocalDate;
 import com.google.gson.annotations.SerializedName;
 import com.mx.path.model.mdx.model.MdxBase;
 import com.mx.path.model.mdx.model.MdxRelationId;
-import com.mx.path.model.mdx.model.UserIdProvider;
 import com.mx.path.model.mdx.model.account.Account;
 
 public final class RemoteDeposit extends MdxBase<RemoteDeposit> {
@@ -28,10 +27,6 @@ public final class RemoteDeposit extends MdxBase<RemoteDeposit> {
   private String status;
   private Long updatedAt;
   private LocalDate updatedOn;
-
-  public RemoteDeposit() {
-    UserIdProvider.setUserId(this);
-  }
 
   @MdxRelationId(referredClass = Account.class)
   public String getAccountId() {

--- a/mdx-models/src/main/java/com/mx/path/model/mdx/model/transfer/RecurringTransfer.java
+++ b/mdx-models/src/main/java/com/mx/path/model/mdx/model/transfer/RecurringTransfer.java
@@ -9,7 +9,6 @@ import lombok.Getter;
 
 import com.mx.path.model.mdx.model.MdxBase;
 import com.mx.path.model.mdx.model.MdxRelationId;
-import com.mx.path.model.mdx.model.UserIdProvider;
 import com.mx.path.model.mdx.model.account.Account;
 import com.mx.path.model.mdx.model.challenges.Challenge;
 
@@ -37,10 +36,6 @@ public final class RecurringTransfer extends MdxBase<RecurringTransfer> {
   @Getter(onMethod_ = { @MdxRelationId(referredClass = Account.class) })
   private String toAccountId;
   private String transferType;
-
-  public RecurringTransfer() {
-    UserIdProvider.setUserId(this);
-  }
 
   public List<Challenge> getChallenges() {
     return challenges;

--- a/mdx-models/src/main/java/com/mx/path/model/mdx/model/transfer/Transfer.java
+++ b/mdx-models/src/main/java/com/mx/path/model/mdx/model/transfer/Transfer.java
@@ -9,7 +9,6 @@ import lombok.Getter;
 
 import com.mx.path.model.mdx.model.MdxBase;
 import com.mx.path.model.mdx.model.MdxRelationId;
-import com.mx.path.model.mdx.model.UserIdProvider;
 import com.mx.path.model.mdx.model.account.Account;
 import com.mx.path.model.mdx.model.challenges.Challenge;
 
@@ -47,9 +46,5 @@ public final class Transfer extends MdxBase<Transfer> {
 
   public void setChallenges(List<Challenge> challenges) {
     this.challenges = challenges;
-  }
-
-  public Transfer() {
-    UserIdProvider.setUserId(this);
   }
 }


### PR DESCRIPTION
# Summary of Changes

Alternative implementation of https://github.com/mxenabled/path-mdx-model/pull/173 

This gets us closer to removing the antiquated UserIDProvider. Marking it deprecated for future removal.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
