### PR TITLE
Adding new endpoint for MDX account numbers (not to be confused with On Demand)

### DIFF
--- a/mdx-web/src/main/java/com/mx/path/model/mdx/web/controller/AccountNumbersController.java
+++ b/mdx-web/src/main/java/com/mx/path/model/mdx/web/controller/AccountNumbersController.java
@@ -14,8 +14,14 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping(value = "{clientId}")
 public class AccountNumbersController extends BaseController {
   @RequestMapping(value = "/accounts/{id}/account_numbers", method = RequestMethod.GET, produces = BaseController.MDX_ONDEMAND_MEDIA)
-  public final ResponseEntity<AccountNumbers> get(@PathVariable("id") String accountId) throws Exception {
+  public final ResponseEntity<AccountNumbers> getOnDemandAccountNumbers(@PathVariable("id") String accountId) throws Exception {
     ensureFeature("accounts");
+    AccessorResponse<AccountNumbers> response = gateway().accounts().accountNumbers().get(accountId);
+    return new ResponseEntity<>(response.getResult().wrapped(), createMultiMapForResponse(response.getHeaders()), HttpStatus.OK);
+  }
+
+  @RequestMapping(value = "/users/{userId}/accounts/{id}/account_number", method = RequestMethod.GET, produces = BaseController.MDX_MEDIA)
+  public final ResponseEntity<AccountNumbers> getAccountNumbers(@PathVariable("id") String accountId) throws Exception {
     AccessorResponse<AccountNumbers> response = gateway().accounts().accountNumbers().get(accountId);
     return new ResponseEntity<>(response.getResult().wrapped(), createMultiMapForResponse(response.getHeaders()), HttpStatus.OK);
   }

--- a/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/AccountNumbersControllerTest.groovy
+++ b/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/AccountNumbersControllerTest.groovy
@@ -35,6 +35,22 @@ class AccountNumbersControllerTest extends Specification {
     RequestContext.clear()
   }
 
+  def "gets on demand account numbers for an account"() {
+    given:
+    AccountsController.setGateway(gateway)
+    def accountNumbers = new AccountNumbers()
+
+    when:
+    doReturn(new AccessorResponse<AccountNumbers>().withResult(accountNumbers)).when(accountNumberGateway).get("A-123")
+    def result = subject.getOnDemandAccountNumbers("A-123")
+
+    then:
+    verify(accountGateway).accountNumbers() || true
+    verify(accountNumberGateway).get("A-123") || true
+    result.getBody() == accountNumbers
+    RequestContext.current().feature == "accounts"
+  }
+
   def "gets account numbers for an account"() {
     given:
     AccountsController.setGateway(gateway)
@@ -42,12 +58,11 @@ class AccountNumbersControllerTest extends Specification {
 
     when:
     doReturn(new AccessorResponse<AccountNumbers>().withResult(accountNumbers)).when(accountNumberGateway).get("A-123")
-    def result = subject.get("A-123")
+    def result = subject.getAccountNumbers("A-123")
 
     then:
     verify(accountGateway).accountNumbers() || true
     verify(accountNumberGateway).get("A-123") || true
     result.getBody() == accountNumbers
-    RequestContext.current().feature == "accounts"
   }
 }


### PR DESCRIPTION
# Summary of Changes

https://mxcom.atlassian.net/browse/GCU-290

Acceptance Criteria

From within account details when viewing the masked electronic account number, if a GCU user taps “Show” to view the electronic account number, MX should make the upstream API call to retrieve the account number.

MX plans to retrieve the electronic account number from SymXchange

MX will NOT store the electronic ACH account number 

Data is to be stored in device cache ONLY

Data will be cleared either when the session times out or the users logs out

From an InfoSec perspective, we need to make sure not to log the electronic account number

## Downstream Consumer Impact

As a user with certain held GCU shares and loans for which electronic account numbers can be associated, I want to be able to view and copy the electronic account number so that I use it for setting up direct deposit or ACH transfers.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
