### PR TITLE
Add rank field to Email

### DIFF
--- a/mdx-models/src/main/java/com/mx/path/model/mdx/model/profile/Email.java
+++ b/mdx-models/src/main/java/com/mx/path/model/mdx/model/profile/Email.java
@@ -9,12 +9,12 @@ import com.mx.path.model.mdx.model.challenges.Challenge;
 public final class Email extends MdxBase<Email> {
 
   private List<Challenge> challenges;
-
   @SerializedName("email_address")
   private String emailAddress;
   @SerializedName("email_type")
   private String emailType;
   private String id;
+  private String rank;
 
   public Email() {
   }
@@ -49,6 +49,14 @@ public final class Email extends MdxBase<Email> {
 
   public void setId(String id) {
     this.id = id;
+  }
+
+  public String getRank() {
+    return rank;
+  }
+
+  public void setRank(String rank) {
+    this.rank = rank;
   }
 
   public enum EmailType {

--- a/mdx-models/src/main/java/com/mx/path/model/mdx/model/profile/Email.java
+++ b/mdx-models/src/main/java/com/mx/path/model/mdx/model/profile/Email.java
@@ -12,10 +12,10 @@ public final class Email extends MdxBase<Email> {
   @SerializedName("email_address")
   private String emailAddress;
   @SerializedName("email_type")
-  private String emailType;
+  private EmailType emailType;
   private String id;
   @SerializedName("rank")
-  private String rank;
+  private Rank rank;
 
   public Email() {
   }
@@ -36,11 +36,11 @@ public final class Email extends MdxBase<Email> {
     this.emailAddress = emailAddress;
   }
 
-  public String getEmailType() {
+  public EmailType getEmailType() {
     return emailType;
   }
 
-  public void setEmailType(String emailType) {
+  public void setEmailType(EmailType emailType) {
     this.emailType = emailType;
   }
 
@@ -52,11 +52,11 @@ public final class Email extends MdxBase<Email> {
     this.id = id;
   }
 
-  public String getRank() {
+  public Rank getRank() {
     return rank;
   }
 
-  public void setRank(String rank) {
+  public void setRank(Rank rank) {
     this.rank = rank;
   }
 

--- a/mdx-models/src/main/java/com/mx/path/model/mdx/model/profile/Email.java
+++ b/mdx-models/src/main/java/com/mx/path/model/mdx/model/profile/Email.java
@@ -14,6 +14,7 @@ public final class Email extends MdxBase<Email> {
   @SerializedName("email_type")
   private String emailType;
   private String id;
+  @SerializedName("rank")
   private String rank;
 
   public Email() {
@@ -61,5 +62,9 @@ public final class Email extends MdxBase<Email> {
 
   public enum EmailType {
     BUSINESS, PERSONAL
+  }
+
+  public enum Rank {
+    PRIMARY, SECONDARY, TERTIARY
   }
 }

--- a/mdx-models/src/main/java/com/mx/path/model/mdx/model/profile/Phone.java
+++ b/mdx-models/src/main/java/com/mx/path/model/mdx/model/profile/Phone.java
@@ -13,6 +13,7 @@ public final class Phone extends MdxBase<Phone> {
   private String phoneNumber;
   @SerializedName("phone_type")
   private String phoneType;
+  @SerializedName("rank")
   private String rank;
   @SerializedName("work_extension")
   private String workExtension;
@@ -70,5 +71,9 @@ public final class Phone extends MdxBase<Phone> {
 
   public enum PhoneType {
     MOBILE, HOME, WORK, FOREIGN
+  }
+
+  public enum Rank {
+    PRIMARY, SECONDARY, TERTIARY
   }
 }

--- a/mdx-models/src/main/java/com/mx/path/model/mdx/model/profile/Phone.java
+++ b/mdx-models/src/main/java/com/mx/path/model/mdx/model/profile/Phone.java
@@ -12,9 +12,9 @@ public final class Phone extends MdxBase<Phone> {
   @SerializedName("phone_number")
   private String phoneNumber;
   @SerializedName("phone_type")
-  private String phoneType;
+  private PhoneType phoneType;
   @SerializedName("rank")
-  private String rank;
+  private Rank rank;
   @SerializedName("work_extension")
   private String workExtension;
 
@@ -45,19 +45,19 @@ public final class Phone extends MdxBase<Phone> {
     this.phoneNumber = phoneNumber;
   }
 
-  public String getPhoneType() {
+  public PhoneType getPhoneType() {
     return phoneType;
   }
 
-  public void setPhoneType(String phoneType) {
+  public void setPhoneType(PhoneType phoneType) {
     this.phoneType = phoneType;
   }
 
-  public String getRank() {
+  public Rank getRank() {
     return rank;
   }
 
-  public void setRank(String rank) {
+  public void setRank(Rank rank) {
     this.rank = rank;
   }
 


### PR DESCRIPTION
# Summary of Changes

Adds `rank` field to `Email` as enum.

Updated `rank` field to `Phone` to be an enum.

Issue: https://mxcom.atlassian.net/browse/HW2-604

Related MRs:
- `gutenberg`: https://gitlab.mx.com/mx/gutenberg/-/merge_requests/823

## Public API Additions/Changes

- `com.mx.path.model.mdx.model.profile.Email` updated with `rank`

## Downstream Consumer Impact

The mobile app will be able to determine priority of email addresses based on the `rank` field.


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings