### PR TITLE
feat: add device_registration field to authentication

### DIFF
--- a/mdx-models/src/main/java/com/mx/path/model/mdx/model/id/Authentication.java
+++ b/mdx-models/src/main/java/com/mx/path/model/mdx/model/id/Authentication.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import com.google.gson.annotations.SerializedName;
 import com.mx.path.model.mdx.model.MdxBase;
+import com.mx.path.model.mdx.model.id.v20240213.Authentication.DeviceRegistration;
 
 public class Authentication extends MdxBase<Authentication> {
 
@@ -25,6 +26,7 @@ public class Authentication extends MdxBase<Authentication> {
   private String deviceOperatingSystemVersion;
   private Double deviceLatitude;
   private Double deviceLongitude;
+  private DeviceRegistration deviceRegistration;
   private Integer deviceWidth;
   private String id;
   @SerializedName("device_iovation_token")
@@ -170,6 +172,14 @@ public class Authentication extends MdxBase<Authentication> {
 
   public final void setDeviceWidth(int newDeviceWidth) {
     this.deviceWidth = newDeviceWidth;
+  }
+
+  public final void setDeviceRegistration(DeviceRegistration deviceRegistration) {
+    this.deviceRegistration = deviceRegistration;
+  }
+
+  public final DeviceRegistration getDeviceRegistration() {
+    return deviceRegistration;
   }
 
   public final String getId() {

--- a/mdx-models/src/main/java/com/mx/path/model/mdx/model/id/v20240213/Authentication.java
+++ b/mdx-models/src/main/java/com/mx/path/model/mdx/model/id/v20240213/Authentication.java
@@ -10,6 +10,11 @@ import com.mx.path.model.mdx.model.challenges.Challenge;
 
 @Data
 public class Authentication extends MdxBase<Authentication> {
+  public enum DeviceRegistration {
+    PRIMARY,
+    SECONDARY
+  }
+
   private final String version = "20240213";
 
   private List<Challenge> challenges;
@@ -24,6 +29,7 @@ public class Authentication extends MdxBase<Authentication> {
   private String deviceOperatingSystemVersion;
   private Double deviceLatitude;
   private Double deviceLongitude;
+  private DeviceRegistration deviceRegistration;
   private Integer deviceWidth;
   private String id;
   @SerializedName("device_iovation_token")


### PR DESCRIPTION
# Summary of Changes

This adds device registration field to authentication class to support upstream services handling the device registration.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
