### PR TITLE
fix: updated response code to OK from Accepted

### DIFF
--- a/mdx-web/src/main/java/com/mx/path/model/mdx/web/controller/DocumentsController.java
+++ b/mdx-web/src/main/java/com/mx/path/model/mdx/web/controller/DocumentsController.java
@@ -46,6 +46,6 @@ public class DocumentsController extends BaseController {
   @RequestMapping(value = "/users/{userId}/documents/delivery_preferences", method = RequestMethod.PUT)
   public final ResponseEntity<DeliveryPreferences> updateDeliveryPreferences(@RequestBody DeliveryPreferences deliveryPreferences) {
     AccessorResponse<DeliveryPreferences> response = gateway().documents().updateDeliveryPreferences(deliveryPreferences);
-    return new ResponseEntity<>(response.getResult().wrapped(), createMultiMapForResponse(response.getHeaders()), HttpStatus.ACCEPTED);
+    return new ResponseEntity<>(response.getResult().wrapped(), createMultiMapForResponse(response.getHeaders()), HttpStatus.OK);
   }
 }

--- a/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/DocumentsControllerTest.groovy
+++ b/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/DocumentsControllerTest.groovy
@@ -93,6 +93,6 @@ class DocumentsControllerTest extends Specification {
 
     then:
     verify(documentGateway).updateDeliveryPreferences(deliveryPreferences) || true
-    HttpStatus.ACCEPTED == response.getStatusCode()
+    HttpStatus.OK == response.getStatusCode()
   }
 }


### PR DESCRIPTION
# Summary of Changes

As per the spec update discussion we had to correct the response code on this endpoint, we have updated this repo

Gutenberg MR - https://gitlab.mx.com/mx/gutenberg/-/merge_requests/834

Fixes # (issue)

https://mxcom.atlassian.net/browse/HW2-802

## Public API Additions/Changes

https://developer.mx.com/drafts/mdx/documents/#documents-update-delivery-preferences

## Downstream Consumer Impact

FHB is the only other client using this endpoint and they are not going to go live with feature anytime soon and they are informed about this change.


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
