### PR TITLE
Updated GET response code to OK from Accepted

### DIFF
--- a/mdx-web/src/main/java/com/mx/path/model/mdx/web/controller/DocumentsController.java
+++ b/mdx-web/src/main/java/com/mx/path/model/mdx/web/controller/DocumentsController.java
@@ -40,7 +40,7 @@ public class DocumentsController extends BaseController {
     deliveryPreferences.setAccountId(queryParameters.getAccount_id());
     deliveryPreferences.setDocumentType(queryParameters.getDocument_type());
     AccessorResponse<DeliveryPreferences> response = gateway().documents().deliveryPreferences(deliveryPreferences);
-    return new ResponseEntity<>(response.getResult().wrapped(), createMultiMapForResponse(response.getHeaders()), HttpStatus.ACCEPTED);
+    return new ResponseEntity<>(response.getResult().wrapped(), createMultiMapForResponse(response.getHeaders()), HttpStatus.OK);
   }
 
   @RequestMapping(value = "/users/{userId}/documents/delivery_preferences", method = RequestMethod.PUT)

--- a/mdx-web/src/main/java/com/mx/path/model/mdx/web/controller/ProfilesController.java
+++ b/mdx-web/src/main/java/com/mx/path/model/mdx/web/controller/ProfilesController.java
@@ -79,7 +79,7 @@ public class ProfilesController extends BaseController {
   @RequestMapping(value = "/users/{userId}/profile/challenge_questions", method = RequestMethod.GET)
   public final ResponseEntity<ChallengeQuestions> getChallengeQuestions() {
     AccessorResponse<ChallengeQuestions> response = gateway().profiles().challengeQuestions().list();
-    return new ResponseEntity<>(response.getResult().wrapped(), createMultiMapForResponse(response.getHeaders()), HttpStatus.ACCEPTED);
+    return new ResponseEntity<>(response.getResult().wrapped(), createMultiMapForResponse(response.getHeaders()), HttpStatus.OK);
   }
 
   @RequestMapping(value = "/users/{userId}/profile/challenge_questions", method = RequestMethod.PUT, consumes = MDX_MEDIA)

--- a/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/DocumentsControllerTest.groovy
+++ b/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/DocumentsControllerTest.groovy
@@ -78,7 +78,7 @@ class DocumentsControllerTest extends Specification {
 
     then:
     verify(documentGateway).deliveryPreferences(any(DeliveryPreferences)) || true
-    HttpStatus.ACCEPTED == response.getStatusCode()
+    HttpStatus.OK == response.getStatusCode()
   }
 
   def "updateDeliveryPreferences interacts with gateway"() {

--- a/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/ProfilesControllerTest.groovy
+++ b/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/ProfilesControllerTest.groovy
@@ -187,7 +187,7 @@ class ProfilesControllerTest extends Specification {
     then:
     response.body == mockResponse.result
     response.body.wrapped
-    response.statusCode == HttpStatus.ACCEPTED
+    response.statusCode == HttpStatus.OK
   }
 
   def "updateChallengeQuestions_implemented response is 202"() {


### PR DESCRIPTION
# Summary of Changes

As per the spec update discussion we had to correct the response code on this GET endpoint, we have updated this repo
Update happened on 2 GET endpoints,

1. GET delivery preferences
2. GET recovery questions

Gutenberg MR - https://gitlab.mx.com/mx/gutenberg/-/merge_requests/839

Fixes # (issue)

https://mxcom.atlassian.net/browse/HW2-488

## Public API Additions/Changes

https://developer.mx.com/drafts/mdx/documents/#documents-retrieve-delivery-preferences
https://developer.mx.com/drafts/mdx/profile/#security-questions-list-security-questions

## Downstream Consumer Impact

HW is the only client using these endpoints and no accessor changes will be needed. Synch and mobile changes are in progress to make sure we don't break the flow.


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
