### PR TITLE
fix: adding PERSONAL for backward compatibility

### DIFF
--- a/mdx-models/src/main/java/com/mx/path/model/mdx/model/profile/Phone.java
+++ b/mdx-models/src/main/java/com/mx/path/model/mdx/model/profile/Phone.java
@@ -70,7 +70,7 @@ public final class Phone extends MdxBase<Phone> {
   }
 
   public enum PhoneType {
-    MOBILE, HOME, WORK, FOREIGN
+    MOBILE, HOME, WORK, FOREIGN, PERSONAL
   }
 
   public enum Rank {


### PR DESCRIPTION
I'm running into services that used "PERSONAL" as the default phone type. For backward compatibility we should add this to the now-forced enum.