### PR TITLE
Adding RecoveryQuestions to Profile Controller

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,8 +6,7 @@ plugins {
   id "io.github.gradle-nexus.publish-plugin" version "1.1.+"
 }
 
-version "10.0.3" // x-release-please-version
-
+version "10.0.1" // x-release-please-version
 def platformProject = "platform"
 def publishedProjects = [
   platformProject,

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
   id "io.github.gradle-nexus.publish-plugin" version "1.1.+"
 }
 
-version "10.0.1" // x-release-please-version
+version "10.0.3" // x-release-please-version
 
 def platformProject = "platform"
 def publishedProjects = [

--- a/mdx-models/src/main/java/com/mx/path/model/mdx/accessor/profile/ChallengeQuestionBaseAccessor.java
+++ b/mdx-models/src/main/java/com/mx/path/model/mdx/accessor/profile/ChallengeQuestionBaseAccessor.java
@@ -12,6 +12,7 @@ import com.mx.path.model.mdx.model.profile.ChallengeQuestions;
 /**
  * Accessor base for profile challenge questions
  */
+@Deprecated
 @GatewayClass
 @API(specificationUrl = "https://developer.mx.com/drafts/mdx/profile/index.html#challenge-questions")
 public class ChallengeQuestionBaseAccessor extends Accessor {

--- a/mdx-models/src/main/java/com/mx/path/model/mdx/accessor/profile/ProfileBaseAccessor.java
+++ b/mdx-models/src/main/java/com/mx/path/model/mdx/accessor/profile/ProfileBaseAccessor.java
@@ -37,6 +37,10 @@ public class ProfileBaseAccessor extends Accessor {
 
   @GatewayAPI
   @Getter(AccessLevel.PROTECTED)
+  private SecurityQuestionBaseAccessor securityQuestions;
+
+  @GatewayAPI
+  @Getter(AccessLevel.PROTECTED)
   private EmailBaseAccessor emails;
 
   @GatewayAPI
@@ -93,12 +97,35 @@ public class ProfileBaseAccessor extends Accessor {
   }
 
   /**
-   * Set challege questions accessor
+   * Set challenge questions accessor
    *
    * @param challengeQuestions
    */
   public void setChallengeQuestions(ChallengeQuestionBaseAccessor challengeQuestions) {
     this.challengeQuestions = challengeQuestions;
+  }
+
+  /**
+   * Accessor for security question operations
+   *
+   * @return accessor
+   */
+  @API(specificationUrl = "https://developer.mx.com/drafts/mdx/profile/index.html#security-questions")
+  public SecurityQuestionBaseAccessor securityQuestions() {
+    if (securityQuestions != null) {
+      return securityQuestions;
+    }
+
+    throw new AccessorMethodNotImplementedException();
+  }
+
+  /**
+   * Set security questions accessor
+   *
+   * @param securityQuestions
+   */
+  public void setSecurityQuestions(SecurityQuestionBaseAccessor securityQuestions) {
+    this.securityQuestions = securityQuestions;
   }
 
   /**

--- a/mdx-models/src/main/java/com/mx/path/model/mdx/accessor/profile/SecurityQuestionBaseAccessor.java
+++ b/mdx-models/src/main/java/com/mx/path/model/mdx/accessor/profile/SecurityQuestionBaseAccessor.java
@@ -18,7 +18,6 @@ public class SecurityQuestionBaseAccessor extends Accessor {
   public SecurityQuestionBaseAccessor() {
   }
 
-  @Deprecated
   public SecurityQuestionBaseAccessor(AccessorConfiguration configuration) {
     super(configuration);
   }

--- a/mdx-models/src/main/java/com/mx/path/model/mdx/accessor/profile/SecurityQuestionBaseAccessor.java
+++ b/mdx-models/src/main/java/com/mx/path/model/mdx/accessor/profile/SecurityQuestionBaseAccessor.java
@@ -1,0 +1,46 @@
+package com.mx.path.model.mdx.accessor.profile;
+
+import com.mx.path.core.common.accessor.API;
+import com.mx.path.core.common.accessor.AccessorMethodNotImplementedException;
+import com.mx.path.core.common.gateway.GatewayAPI;
+import com.mx.path.core.common.gateway.GatewayClass;
+import com.mx.path.gateway.accessor.Accessor;
+import com.mx.path.gateway.accessor.AccessorConfiguration;
+import com.mx.path.gateway.accessor.AccessorResponse;
+import com.mx.path.model.mdx.model.profile.SecurityQuestions;
+
+/**
+ * Accessor base for profile security questions
+ */
+@GatewayClass
+@API(specificationUrl = "https://developer.mx.com/drafts/mdx/profile/index.html#security-questions")
+public class SecurityQuestionBaseAccessor extends Accessor {
+  public SecurityQuestionBaseAccessor() {
+  }
+
+  @Deprecated
+  public SecurityQuestionBaseAccessor(AccessorConfiguration configuration) {
+    super(configuration);
+  }
+
+  /**
+   * Lists security questions
+   * @return
+   */
+  @GatewayAPI
+  @API(description = "List security questions")
+  public AccessorResponse<SecurityQuestions> list() {
+    throw new AccessorMethodNotImplementedException();
+  }
+
+  /**
+   * Updates security questions
+   * @param securityQuestions
+   * @return
+   */
+  @GatewayAPI
+  @API(description = "update security questions")
+  public AccessorResponse<SecurityQuestions> update(SecurityQuestions securityQuestions) {
+    throw new AccessorMethodNotImplementedException();
+  }
+}

--- a/mdx-models/src/main/java/com/mx/path/model/mdx/model/Resources.java
+++ b/mdx-models/src/main/java/com/mx/path/model/mdx/model/Resources.java
@@ -89,6 +89,7 @@ import com.mx.path.model.mdx.model.profile.NewUserName;
 import com.mx.path.model.mdx.model.profile.Password;
 import com.mx.path.model.mdx.model.profile.Phone;
 import com.mx.path.model.mdx.model.profile.Profile;
+import com.mx.path.model.mdx.model.profile.SecurityQuestions;
 import com.mx.path.model.mdx.model.profile.UserName;
 import com.mx.path.model.mdx.model.remote_deposit.Limits;
 import com.mx.path.model.mdx.model.remote_deposit.RemoteDeposit;
@@ -324,6 +325,8 @@ public class Resources {
     builder.registerTypeAdapter(Address.class, new ModelWrappableSerializer("address"));
     // Challenge Questions
     builder.registerTypeAdapter(ChallengeQuestions.class, new ModelWrappableSerializer("challenge_questions"));
+    // Security Questions
+    builder.registerTypeAdapter(SecurityQuestions.class, new ModelWrappableSerializer("security_questions"));
     builder.registerTypeAdapter(new TypeToken<MdxList<Address>>() {
     }.getType(), new ModelWrappableSerializer("addresses"));
     // Phones

--- a/mdx-models/src/main/java/com/mx/path/model/mdx/model/profile/SecurityQuestions.java
+++ b/mdx-models/src/main/java/com/mx/path/model/mdx/model/profile/SecurityQuestions.java
@@ -5,14 +5,17 @@ import java.util.List;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
+import com.google.gson.annotations.SerializedName;
 import com.mx.path.model.mdx.model.MdxBase;
 import com.mx.path.model.mdx.model.challenges.Challenge;
 
-@Deprecated
 @EqualsAndHashCode(callSuper = true)
 @Data
-public final class ChallengeQuestions extends MdxBase<ChallengeQuestions> {
+public final class SecurityQuestions extends MdxBase<SecurityQuestions> {
   private List<Challenge> challenges;
+
+  @SerializedName("question_list")
+  private Challenge questionList;
 
   public List<Challenge> getChallenges() {
     return challenges;
@@ -20,5 +23,13 @@ public final class ChallengeQuestions extends MdxBase<ChallengeQuestions> {
 
   public void setChallenges(List<Challenge> challenges) {
     this.challenges = challenges;
+  }
+
+  public Challenge getQuestionList() {
+    return questionList;
+  }
+
+  public void setQuestionList(Challenge questionList) {
+    this.questionList = questionList;
   }
 }

--- a/mdx-web/src/main/java/com/mx/path/model/mdx/web/controller/ProfilesController.java
+++ b/mdx-web/src/main/java/com/mx/path/model/mdx/web/controller/ProfilesController.java
@@ -11,6 +11,7 @@ import com.mx.path.model.mdx.model.profile.NewUserName;
 import com.mx.path.model.mdx.model.profile.Password;
 import com.mx.path.model.mdx.model.profile.Phone;
 import com.mx.path.model.mdx.model.profile.Profile;
+import com.mx.path.model.mdx.model.profile.SecurityQuestions;
 import com.mx.path.model.mdx.model.profile.UserName;
 
 import org.springframework.http.HttpStatus;
@@ -76,12 +77,14 @@ public class ProfilesController extends BaseController {
     return new ResponseEntity<>(createMultiMapForResponse(response.getHeaders()), HttpStatus.NO_CONTENT);
   }
 
+  @Deprecated
   @RequestMapping(value = "/users/{userId}/profile/challenge_questions", method = RequestMethod.GET)
   public final ResponseEntity<ChallengeQuestions> getChallengeQuestions() {
     AccessorResponse<ChallengeQuestions> response = gateway().profiles().challengeQuestions().list();
     return new ResponseEntity<>(response.getResult().wrapped(), createMultiMapForResponse(response.getHeaders()), HttpStatus.OK);
   }
 
+  @Deprecated
   @RequestMapping(value = "/users/{userId}/profile/challenge_questions", method = RequestMethod.PUT, consumes = MDX_MEDIA)
   public final ResponseEntity<ChallengeQuestions> updateChallengeQuestions(@RequestBody ChallengeQuestions challengeQuestions) {
     AccessorResponse<ChallengeQuestions> response = gateway().profiles().challengeQuestions().update(challengeQuestions);
@@ -90,6 +93,22 @@ public class ProfilesController extends BaseController {
       return new ResponseEntity<>(response.getResult().wrapped(), createMultiMapForResponse(response.getHeaders()), HttpStatus.ACCEPTED);
     }
     return new ResponseEntity<>(createMultiMapForResponse(response.getHeaders()), HttpStatus.NO_CONTENT);
+  }
+
+  @RequestMapping(value = "/users/{userId}/profile/security_questions", method = RequestMethod.GET)
+  public final ResponseEntity<SecurityQuestions> getSecurityQuestions() {
+    AccessorResponse<SecurityQuestions> response = gateway().profiles().securityQuestions().list();
+    return new ResponseEntity<>(response.getResult().wrapped(), createMultiMapForResponse(response.getHeaders()), HttpStatus.OK);
+  }
+
+  @RequestMapping(value = "/users/{userId}/profile/security_questions", method = RequestMethod.PUT, consumes = MDX_MEDIA)
+  public final ResponseEntity<SecurityQuestions> updateSecurityQuestions(@RequestBody SecurityQuestions securityQuestions) {
+    AccessorResponse<SecurityQuestions> response = gateway().profiles().securityQuestions().update(securityQuestions);
+    SecurityQuestions result = response.getResult();
+    if (result != null && result.getChallenges() != null && result.getChallenges().size() > 0) {
+      return new ResponseEntity<>(response.getResult().wrapped(), createMultiMapForResponse(response.getHeaders()), HttpStatus.ACCEPTED);
+    }
+    return new ResponseEntity<>(createMultiMapForResponse(response.getHeaders()), HttpStatus.OK);
   }
 
   @RequestMapping(value = "/users/{userId}/profile/phones", method = RequestMethod.GET)

--- a/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/ProfilesControllerTest.groovy
+++ b/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/ProfilesControllerTest.groovy
@@ -13,6 +13,7 @@ import com.mx.path.gateway.api.profile.ChallengeQuestionGateway
 import com.mx.path.gateway.api.profile.EmailGateway
 import com.mx.path.gateway.api.profile.PhoneGateway
 import com.mx.path.gateway.api.profile.ProfileGateway
+import com.mx.path.gateway.api.profile.SecurityQuestionGateway
 import com.mx.path.model.mdx.model.MdxList
 import com.mx.path.model.mdx.model.challenges.Challenge
 import com.mx.path.model.mdx.model.profile.Address
@@ -23,6 +24,7 @@ import com.mx.path.model.mdx.model.profile.NewUserName
 import com.mx.path.model.mdx.model.profile.Password
 import com.mx.path.model.mdx.model.profile.Phone
 import com.mx.path.model.mdx.model.profile.Profile
+import com.mx.path.model.mdx.model.profile.SecurityQuestions
 import com.mx.path.model.mdx.model.profile.UserName
 
 import org.springframework.http.HttpStatus
@@ -35,6 +37,7 @@ class ProfilesControllerTest extends Specification {
   ProfileGateway profileGateway
   AddressGateway addressGateway
   ChallengeQuestionGateway challengeQuestionGateway
+  SecurityQuestionGateway securityQuestionGateway
   EmailGateway emailGateway
   PhoneGateway phoneGateway
   String clientId
@@ -44,9 +47,10 @@ class ProfilesControllerTest extends Specification {
 
     addressGateway = spy(AddressGateway.builder().clientId(clientId).build())
     challengeQuestionGateway = spy(ChallengeQuestionGateway.builder().clientId(clientId).build())
+    securityQuestionGateway = spy(SecurityQuestionGateway.builder().clientId(clientId).build())
     emailGateway = spy(EmailGateway.builder().clientId(clientId).build())
     phoneGateway = spy(PhoneGateway.builder().clientId(clientId).build())
-    profileGateway = spy(ProfileGateway.builder().clientId(clientId).emails(emailGateway).phones(phoneGateway).addresses(addressGateway).challengeQuestions(challengeQuestionGateway).build())
+    profileGateway = spy(ProfileGateway.builder().clientId(clientId).emails(emailGateway).phones(phoneGateway).addresses(addressGateway).challengeQuestions(challengeQuestionGateway).securityQuestions(securityQuestionGateway).build())
     gateway = spy(Gateway.builder().clientId(clientId).profiles(profileGateway).build())
 
     subject = new ProfilesController()
@@ -190,6 +194,22 @@ class ProfilesControllerTest extends Specification {
     response.statusCode == HttpStatus.OK
   }
 
+  def "getSecurityQuestions_implemented"() {
+    given:
+    ProfilesController.setGateway(gateway)
+
+    def mockResponse = new AccessorResponse<SecurityQuestions>().withResult(new SecurityQuestions())
+    doReturn(mockResponse).when(securityQuestionGateway).list()
+
+    when:
+    def response = subject.getSecurityQuestions()
+
+    then:
+    response.body == mockResponse.result
+    response.body.wrapped
+    response.statusCode == HttpStatus.OK
+  }
+
   def "updateChallengeQuestions_implemented response is 202"() {
     given:
     ProfilesController.setGateway(gateway)
@@ -209,6 +229,42 @@ class ProfilesControllerTest extends Specification {
     response.body == mockResponse.result
     response.body.wrapped
     response.statusCode == HttpStatus.ACCEPTED
+  }
+
+  def "updateSecurityQuestions_implemented response is 202"() {
+    given:
+    ProfilesController.setGateway(gateway)
+
+    def mockResponse = new AccessorResponse<SecurityQuestions>().withResult(
+        new SecurityQuestions().tap {
+          setChallenges(new MdxList<Challenge>().tap { add(new Challenge()) })
+          setQuestionList(new Challenge())
+        }
+        )
+
+    doReturn(mockResponse).when(securityQuestionGateway).update(any())
+
+    when:
+    def response = subject.updateSecurityQuestions(new SecurityQuestions())
+
+    then:
+    response.body == mockResponse.result
+    response.body.wrapped
+    response.statusCode == HttpStatus.ACCEPTED
+  }
+
+  def "updateSecurityQuestions_implemented response is 200"() {
+    given:
+    ProfilesController.setGateway(gateway)
+
+    def mockResponse = new AccessorResponse<SecurityQuestions>().withResult(new SecurityQuestions()).withStatus(PathResponseStatus.ACCEPTED)
+    doReturn(mockResponse).when(securityQuestionGateway).update(any())
+
+    when:
+    def response = subject.updateSecurityQuestions(new SecurityQuestions())
+
+    then:
+    response.statusCode == HttpStatus.OK
   }
 
   def "updateChallengeQuestions_implemented response is 204"() {


### PR DESCRIPTION
# Summary of Changes

Deprecating the challengequestions endpoints to add the updated version of it which we call recoveryquestions
https://developer.mx.com/drafts/mdx/profile/#security-questions
Also making sure challenges keyword is reserved for MFA

Fixes # (issue) https://mxcom.atlassian.net/browse/HW2-878

## Public API Additions/Changes

List:  https://developer.mx.com/drafts/mdx/profile/#security-questions-list-security-questions
Update: https://developer.mx.com/drafts/mdx/profile/#security-questions-update-challenge-questions

## Downstream Consumer Impact

Downstream consumers will not be impacted as we are deprecating the current endpoint.

# How Has This Been Tested?

Local Testing via accessor changes has been performed to make these changes work as expected.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
