### PR TITLE
feat: exclude userId from serialized nested objects

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,7 @@ plugins {
 }
 
 version "11.1.0" // x-release-please-version
+
 def platformProject = "platform"
 def publishedProjects = [
   platformProject,

--- a/mdx-models/src/main/java/com/mx/path/model/mdx/model/MdxNested.java
+++ b/mdx-models/src/main/java/com/mx/path/model/mdx/model/MdxNested.java
@@ -1,0 +1,18 @@
+package com.mx.path.model.mdx.model;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Added to MDX model to indicate that the model is typically nested within another model.
+ */
+@Documented
+@Target({ ElementType.TYPE })
+@Inherited
+@Retention(RetentionPolicy.RUNTIME)
+public @interface MdxNested {
+}

--- a/mdx-models/src/main/java/com/mx/path/model/mdx/model/authorization/HtmlPage.java
+++ b/mdx-models/src/main/java/com/mx/path/model/mdx/model/authorization/HtmlPage.java
@@ -3,7 +3,9 @@ package com.mx.path.model.mdx.model.authorization;
 import lombok.Data;
 
 import com.mx.path.model.mdx.model.MdxBase;
+import com.mx.path.model.mdx.model.MdxNested;
 
+@MdxNested
 @Data
 public class HtmlPage extends MdxBase<HtmlPage> {
 

--- a/mdx-models/src/main/java/com/mx/path/model/mdx/model/authorization/JavaScript.java
+++ b/mdx-models/src/main/java/com/mx/path/model/mdx/model/authorization/JavaScript.java
@@ -1,7 +1,9 @@
 package com.mx.path.model.mdx.model.authorization;
 
 import com.mx.path.model.mdx.model.MdxBase;
+import com.mx.path.model.mdx.model.MdxNested;
 
+@MdxNested
 public class JavaScript extends MdxBase<JavaScript> {
 
   private NameValuePair[] arguments;

--- a/mdx-models/src/main/java/com/mx/path/model/mdx/model/authorization/NameValuePair.java
+++ b/mdx-models/src/main/java/com/mx/path/model/mdx/model/authorization/NameValuePair.java
@@ -1,7 +1,9 @@
 package com.mx.path.model.mdx.model.authorization;
 
 import com.mx.path.model.mdx.model.MdxBase;
+import com.mx.path.model.mdx.model.MdxNested;
 
+@MdxNested
 public class NameValuePair extends MdxBase<NameValuePair> {
   private String name;
   private String value;

--- a/mdx-models/src/main/java/com/mx/path/model/mdx/model/challenges/Action.java
+++ b/mdx-models/src/main/java/com/mx/path/model/mdx/model/challenges/Action.java
@@ -2,7 +2,9 @@ package com.mx.path.model.mdx.model.challenges;
 
 import com.google.gson.annotations.SerializedName;
 import com.mx.path.model.mdx.model.MdxBase;
+import com.mx.path.model.mdx.model.MdxNested;
 
+@MdxNested
 public final class Action extends MdxBase<Action> {
   private String id;
   private String type;

--- a/mdx-models/src/main/java/com/mx/path/model/mdx/model/challenges/Button.java
+++ b/mdx-models/src/main/java/com/mx/path/model/mdx/model/challenges/Button.java
@@ -4,7 +4,9 @@ import java.util.List;
 
 import com.google.gson.annotations.SerializedName;
 import com.mx.path.model.mdx.model.MdxBase;
+import com.mx.path.model.mdx.model.MdxNested;
 
+@MdxNested
 public final class Button extends MdxBase<Button> {
   private String type;
   private List<Action> actions;

--- a/mdx-models/src/main/java/com/mx/path/model/mdx/model/challenges/Camera.java
+++ b/mdx-models/src/main/java/com/mx/path/model/mdx/model/challenges/Camera.java
@@ -1,7 +1,9 @@
 package com.mx.path.model.mdx.model.challenges;
 
 import com.mx.path.model.mdx.model.MdxBase;
+import com.mx.path.model.mdx.model.MdxNested;
 
+@MdxNested
 public final class Camera extends MdxBase<Camera> {
 
   private String type;

--- a/mdx-models/src/main/java/com/mx/path/model/mdx/model/challenges/DeepLinkData.java
+++ b/mdx-models/src/main/java/com/mx/path/model/mdx/model/challenges/DeepLinkData.java
@@ -2,7 +2,9 @@ package com.mx.path.model.mdx.model.challenges;
 
 import com.google.gson.annotations.SerializedName;
 import com.mx.path.model.mdx.model.MdxBase;
+import com.mx.path.model.mdx.model.MdxNested;
 
+@MdxNested
 public final class DeepLinkData extends MdxBase<DeepLinkData> {
 
   @SerializedName("deep_link")

--- a/mdx-models/src/main/java/com/mx/path/model/mdx/model/challenges/Format.java
+++ b/mdx-models/src/main/java/com/mx/path/model/mdx/model/challenges/Format.java
@@ -2,7 +2,9 @@ package com.mx.path.model.mdx.model.challenges;
 
 import com.google.gson.annotations.SerializedName;
 import com.mx.path.model.mdx.model.MdxBase;
+import com.mx.path.model.mdx.model.MdxNested;
 
+@MdxNested
 public final class Format extends MdxBase<Format> {
   private String font;
   private String color;

--- a/mdx-models/src/main/java/com/mx/path/model/mdx/model/challenges/HtmlData.java
+++ b/mdx-models/src/main/java/com/mx/path/model/mdx/model/challenges/HtmlData.java
@@ -1,8 +1,10 @@
 package com.mx.path.model.mdx.model.challenges;
 
 import com.mx.path.model.mdx.model.MdxBase;
+import com.mx.path.model.mdx.model.MdxNested;
 import com.mx.path.model.mdx.model.authorization.NameValuePair;
 
+@MdxNested
 public final class HtmlData extends MdxBase<HtmlData> {
 
   private NameValuePair[] cookies;

--- a/mdx-models/src/main/java/com/mx/path/model/mdx/model/challenges/Image.java
+++ b/mdx-models/src/main/java/com/mx/path/model/mdx/model/challenges/Image.java
@@ -1,7 +1,9 @@
 package com.mx.path.model.mdx.model.challenges;
 
 import com.mx.path.model.mdx.model.MdxBase;
+import com.mx.path.model.mdx.model.MdxNested;
 
+@MdxNested
 public final class Image extends MdxBase<Image> {
   private String url;
 

--- a/mdx-models/src/main/java/com/mx/path/model/mdx/model/challenges/InfoData.java
+++ b/mdx-models/src/main/java/com/mx/path/model/mdx/model/challenges/InfoData.java
@@ -1,7 +1,9 @@
 package com.mx.path.model.mdx.model.challenges;
 
 import com.mx.path.model.mdx.model.MdxBase;
+import com.mx.path.model.mdx.model.MdxNested;
 
+@MdxNested
 public final class InfoData extends MdxBase<InfoData> {
   private Format format;
 

--- a/mdx-models/src/main/java/com/mx/path/model/mdx/model/challenges/JsonData.java
+++ b/mdx-models/src/main/java/com/mx/path/model/mdx/model/challenges/JsonData.java
@@ -4,7 +4,9 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 
 import com.mx.path.model.mdx.model.MdxBase;
+import com.mx.path.model.mdx.model.MdxNested;
 
+@MdxNested
 @Data
 @EqualsAndHashCode(callSuper = true)
 public final class JsonData extends MdxBase<JsonData> {

--- a/mdx-models/src/main/java/com/mx/path/model/mdx/model/challenges/Option.java
+++ b/mdx-models/src/main/java/com/mx/path/model/mdx/model/challenges/Option.java
@@ -1,7 +1,9 @@
 package com.mx.path.model.mdx.model.challenges;
 
 import com.mx.path.model.mdx.model.MdxBase;
+import com.mx.path.model.mdx.model.MdxNested;
 
+@MdxNested
 public final class Option extends MdxBase<Option> {
   private String id;
   private String name;

--- a/mdx-models/src/main/java/com/mx/path/model/mdx/model/challenges/Question.java
+++ b/mdx-models/src/main/java/com/mx/path/model/mdx/model/challenges/Question.java
@@ -4,7 +4,9 @@ import java.util.List;
 
 import com.google.gson.annotations.SerializedName;
 import com.mx.path.model.mdx.model.MdxBase;
+import com.mx.path.model.mdx.model.MdxNested;
 
+@MdxNested
 public final class Question extends MdxBase<Question> {
   private String id;
   private String prompt;

--- a/mdx-models/src/main/java/com/mx/path/model/mdx/model/challenges/ShowChallengeModal.java
+++ b/mdx-models/src/main/java/com/mx/path/model/mdx/model/challenges/ShowChallengeModal.java
@@ -1,7 +1,9 @@
 package com.mx.path.model.mdx.model.challenges;
 
 import com.mx.path.model.mdx.model.MdxBase;
+import com.mx.path.model.mdx.model.MdxNested;
 
+@MdxNested
 public final class ShowChallengeModal extends MdxBase<ShowChallengeModal> {
   private Challenge challenge;
 

--- a/mdx-models/src/main/java/com/mx/path/model/mdx/model/challenges/ShowStatus.java
+++ b/mdx-models/src/main/java/com/mx/path/model/mdx/model/challenges/ShowStatus.java
@@ -1,7 +1,9 @@
 package com.mx.path.model.mdx.model.challenges;
 
 import com.mx.path.model.mdx.model.MdxBase;
+import com.mx.path.model.mdx.model.MdxNested;
 
+@MdxNested
 public final class ShowStatus extends MdxBase<ShowStatus> {
   private String message;
   private String type;

--- a/mdx-models/src/main/java/com/mx/path/model/mdx/model/challenges/Text.java
+++ b/mdx-models/src/main/java/com/mx/path/model/mdx/model/challenges/Text.java
@@ -1,7 +1,9 @@
 package com.mx.path.model.mdx.model.challenges;
 
 import com.mx.path.model.mdx.model.MdxBase;
+import com.mx.path.model.mdx.model.MdxNested;
 
+@MdxNested
 public final class Text extends MdxBase<Text> {
   private String characterType;
 

--- a/mdx-models/src/main/java/com/mx/path/model/mdx/model/id/MfaChallenge.java
+++ b/mdx-models/src/main/java/com/mx/path/model/mdx/model/id/MfaChallenge.java
@@ -3,8 +3,10 @@ package com.mx.path.model.mdx.model.id;
 import java.util.List;
 
 import com.mx.path.model.mdx.model.MdxBase;
+import com.mx.path.model.mdx.model.MdxNested;
 import com.mx.path.model.mdx.model.authorization.Authorization;
 
+@MdxNested
 public final class MfaChallenge extends MdxBase<MfaChallenge> {
 
   private String answer;

--- a/mdx-models/src/main/java/com/mx/path/model/mdx/model/id/MfaChallengeOption.java
+++ b/mdx-models/src/main/java/com/mx/path/model/mdx/model/id/MfaChallengeOption.java
@@ -1,7 +1,9 @@
 package com.mx.path.model.mdx.model.id;
 
 import com.mx.path.model.mdx.model.MdxBase;
+import com.mx.path.model.mdx.model.MdxNested;
 
+@MdxNested
 public class MfaChallengeOption extends MdxBase<MfaChallengeOption> {
   private String id;
   private String name;

--- a/mdx-models/src/main/java/com/mx/path/model/mdx/model/id/MfaChallengeQuestion.java
+++ b/mdx-models/src/main/java/com/mx/path/model/mdx/model/id/MfaChallengeQuestion.java
@@ -3,9 +3,10 @@ package com.mx.path.model.mdx.model.id;
 import java.util.List;
 
 import com.mx.path.model.mdx.model.MdxBase;
+import com.mx.path.model.mdx.model.MdxNested;
 
+@MdxNested
 public class MfaChallengeQuestion extends MdxBase<MfaChallengeQuestion> {
-
   private String answer;
   private String id;
   private List<MfaChallengeOption> options;

--- a/mdx-models/src/main/java/com/mx/path/model/mdx/model/location/Location.java
+++ b/mdx-models/src/main/java/com/mx/path/model/mdx/model/location/Location.java
@@ -3,7 +3,9 @@ package com.mx.path.model.mdx.model.location;
 import java.time.LocalDate;
 
 import com.mx.path.model.mdx.model.MdxBase;
+import com.mx.path.model.mdx.model.MdxNested;
 
+@MdxNested
 public final class Location extends MdxBase<Location> {
 
   private String address;

--- a/mdx-models/src/test/groovy/com/mx/path/model/mdx/model/MdxBaseTest.groovy
+++ b/mdx-models/src/test/groovy/com/mx/path/model/mdx/model/MdxBaseTest.groovy
@@ -2,6 +2,7 @@ package com.mx.path.model.mdx.model
 
 import com.mx.path.core.common.model.Warning
 import com.mx.path.model.mdx.model.account.Account
+import com.mx.testing.MdxBaseNested
 
 import spock.lang.Specification
 
@@ -28,5 +29,18 @@ class MdxBaseTest extends Specification {
 
     then:
     warnings.size() == 2
+  }
+
+  def "setUserId"() {
+    given:
+    def nestedSubject = new MdxBaseNested()
+
+    when:
+    subject.setUserId("123")
+    nestedSubject.setUserId("123")
+
+    then:
+    subject.getUserId() == "123"
+    nestedSubject.getUserId() == null
   }
 }

--- a/mdx-models/src/test/java/com/mx/testing/MdxBaseNested.java
+++ b/mdx-models/src/test/java/com/mx/testing/MdxBaseNested.java
@@ -1,0 +1,8 @@
+package com.mx.testing;
+
+import com.mx.path.model.mdx.model.MdxBase;
+import com.mx.path.model.mdx.model.MdxNested;
+
+@MdxNested
+public class MdxBaseNested extends MdxBase<MdxBaseNested> {
+}


### PR DESCRIPTION
# Summary of Changes

Add a new annotation to exclude the userId field from MdxBase from serializing on classes that are nested.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
