### PR TITLE
fix: respond with status 400 if the input payload is unparsable

### DIFF
--- a/mdx-web/src/main/java/com/mx/path/model/mdx/web/DateVersionedResponse.java
+++ b/mdx-web/src/main/java/com/mx/path/model/mdx/web/DateVersionedResponse.java
@@ -92,7 +92,7 @@ public class DateVersionedResponse {
         try {
           requestObject = gson.fromJson(requestBody, requestType);
         } catch (Exception e) {
-          throw new PathRequestSerializableException();
+          throw new WebPathRequestSerializationException(requestType.getTypeName(), e);
         }
       }
 

--- a/mdx-web/src/main/java/com/mx/path/model/mdx/web/WebPathRequestSerializationException.java
+++ b/mdx-web/src/main/java/com/mx/path/model/mdx/web/WebPathRequestSerializationException.java
@@ -1,0 +1,13 @@
+package com.mx.path.model.mdx.web;
+
+import com.mx.path.core.common.accessor.PathResponseStatus;
+import com.mx.path.core.common.serialization.PathRequestSerializableException;
+
+public class WebPathRequestSerializationException extends PathRequestSerializableException {
+  public WebPathRequestSerializationException(String originalType, Throwable cause) {
+    super();
+    super.initCause(cause);
+    this.setOriginalType(originalType);
+    this.setStatus(PathResponseStatus.BAD_REQUEST);
+  }
+}


### PR DESCRIPTION
# Summary of Changes

Current behavior is to respond with 500 if we are unable to deserialize the input. This changes to use a custom exception that will set the status to 400.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
