### PR TITLE
Update security questions 200 response needs a body returned

### DIFF
--- a/mdx-web/src/main/java/com/mx/path/model/mdx/web/controller/ProfilesController.java
+++ b/mdx-web/src/main/java/com/mx/path/model/mdx/web/controller/ProfilesController.java
@@ -108,7 +108,7 @@ public class ProfilesController extends BaseController {
     if (result != null && result.getChallenges() != null && result.getChallenges().size() > 0) {
       return new ResponseEntity<>(response.getResult().wrapped(), createMultiMapForResponse(response.getHeaders()), HttpStatus.ACCEPTED);
     }
-    return new ResponseEntity<>(createMultiMapForResponse(response.getHeaders()), HttpStatus.OK);
+    return new ResponseEntity<>(response.getResult().wrapped(), createMultiMapForResponse(response.getHeaders()), HttpStatus.OK);
   }
 
   @RequestMapping(value = "/users/{userId}/profile/phones", method = RequestMethod.GET)


### PR DESCRIPTION
# Summary of Changes

This is a followup MR for https://github.com/mxenabled/path-mdx-model/pull/203 which was recently introduced.
The response body should not be empty for a 200 response acc to the spec hence making this change.
https://developer.mx.com/drafts/mdx/profile/#security-questions-update-challenge-questions

Fixes # (issue)
https://mxcom.atlassian.net/browse/HW2-878

## Public API Additions/Changes

https://developer.mx.com/drafts/mdx/profile/#security-questions-update-challenge-questions

## Downstream Consumer Impact

No Downstream impact as this is being introduced as a new endpoint which we recently introduced a week ago.

# How Has This Been Tested?

Tested Locally 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
