### PR TITLE
feat: add status query param to list transactions

### DIFF
--- a/mdx-models/src/main/java/com/mx/path/model/mdx/model/account/options/TransactionListOptions.java
+++ b/mdx-models/src/main/java/com/mx/path/model/mdx/model/account/options/TransactionListOptions.java
@@ -8,4 +8,5 @@ import lombok.Data;
 @Data
 public class TransactionListOptions {
   private String checkNumber;
+  private String status;
 }

--- a/mdx-web/src/main/java/com/mx/path/model/mdx/web/controller/AccountsController.java
+++ b/mdx-web/src/main/java/com/mx/path/model/mdx/web/controller/AccountsController.java
@@ -11,6 +11,7 @@ import com.mx.path.model.mdx.model.account.Transaction;
 import com.mx.path.model.mdx.model.account.TransactionSearchRequest;
 import com.mx.path.model.mdx.model.account.TransactionsPage;
 import com.mx.path.model.mdx.model.account.options.TransactionListOptions;
+import com.mx.path.model.mdx.web.model.transaction.TransactionListQueryParameters;
 
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -20,7 +21,6 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -93,9 +93,10 @@ public class AccountsController extends BaseController {
   }
 
   @RequestMapping(value = "/users/{userId}/accounts/{accountId}/transactions", method = RequestMethod.GET)
-  public final ResponseEntity<MdxList<Transaction>> listTransactions(@PathVariable("accountId") String accountId, @RequestParam("check_number") String checkNumber) throws Exception {
+  public final ResponseEntity<MdxList<Transaction>> listTransactions(@PathVariable("accountId") String accountId, TransactionListQueryParameters queryParameters) throws Exception {
     TransactionListOptions transactionListOptions = new TransactionListOptions();
-    transactionListOptions.setCheckNumber(checkNumber);
+    transactionListOptions.setCheckNumber(queryParameters.getCheck_number());
+    transactionListOptions.setStatus(queryParameters.getStatus());
     AccessorResponse<MdxList<Transaction>> response = gateway().accounts().transactions().list(accountId, transactionListOptions);
     return new ResponseEntity<>(response.getResult().wrapped(), createMultiMapForResponse(response.getHeaders()), HttpStatus.OK);
   }

--- a/mdx-web/src/main/java/com/mx/path/model/mdx/web/model/transaction/TransactionListQueryParameters.java
+++ b/mdx-web/src/main/java/com/mx/path/model/mdx/web/model/transaction/TransactionListQueryParameters.java
@@ -1,0 +1,10 @@
+package com.mx.path.model.mdx.web.model.transaction;
+
+import lombok.Data;
+
+@SuppressWarnings({ "checkstyle:MemberName", "checkstyle:ParameterName", "checkstyle:MethodName" })
+@Data
+public class TransactionListQueryParameters {
+  private String check_number;
+  private String status;
+}

--- a/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/AccountsControllerTest.groovy
+++ b/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/AccountsControllerTest.groovy
@@ -1,5 +1,7 @@
 package com.mx.path.model.mdx.web.controller
 
+import static org.mockito.ArgumentMatchers.any
+import static org.mockito.ArgumentMatchers.anyString
 import static org.mockito.Mockito.spy
 import static org.mockito.Mockito.verify
 
@@ -15,8 +17,10 @@ import com.mx.path.model.mdx.model.account.TransactionSearchRequest
 import com.mx.path.model.mdx.model.account.TransactionsPage
 import com.mx.path.model.mdx.model.account.options.TransactionListOptions
 import com.mx.path.model.mdx.model.challenges.Challenge
+import com.mx.path.model.mdx.web.model.transaction.TransactionListQueryParameters
 import com.mx.path.testing.WithMockery
 
+import org.mockito.ArgumentCaptor
 import org.mockito.Mockito
 import org.springframework.http.HttpStatus
 
@@ -203,15 +207,23 @@ class AccountsControllerTest extends Specification implements WithMockery {
     MdxList<Transaction> transactions = new MdxList<Transaction>()
     def checkNumber = "4321"
     def accountId = "A-123"
-    TransactionListOptions transactionListOptions = new TransactionListOptions()
-    transactionListOptions.checkNumber = checkNumber
+    def transactionStatus = "PENDING"
+    TransactionListQueryParameters parameters = new TransactionListQueryParameters().tap {
+      check_number = checkNumber
+      status = transactionStatus
+    }
 
     when:
-    Mockito.doReturn(new AccessorResponse<MdxList<Transaction>>().withResult(transactions)).when(transactionGateway).list(accountId, transactionListOptions)
-    def result = subject.listTransactions(accountId, checkNumber)
+    Mockito.doReturn(new AccessorResponse<MdxList<Transaction>>().withResult(transactions))
+        .when(transactionGateway)
+        .list(anyString(), any(TransactionListOptions))
+    def result = subject.listTransactions(accountId, parameters)
 
     then:
-    verify(transactionGateway).list(accountId, transactionListOptions) || true
+    ArgumentCaptor<TransactionListOptions> captor = ArgumentCaptor.forClass(TransactionListOptions)
+    verify(transactionGateway).list(anyString(), captor.capture()) || true
     result.body == transactions
+    captor.value.checkNumber == checkNumber
+    captor.value.status == transactionStatus
   }
 }


### PR DESCRIPTION
# Summary of Changes

Adds status query parameter to the v6 search transactions endpoint https://developer.mx.com/drafts/mdx/accounts/#transactions-search-transactions

## Downstream Consumer Impact

This changes the parameters for in the Controller but I don't think it's a breaking change.

# How Has This Been Tested?

I tested locally. And did a simple test to verify that the query parameters are getting set correctly

```
GET /accounts/{account_id}/transactions?check_number=abcd1234&status=PENDING

HTTP/1.1 200 
Content-Type: application/vnd.mx.mdx.v6+json;charset=UTF-8
Transfer-Encoding: chunked
Date: Tue, 04 Jun 2024 14:26:11 GMT

{
  "transactions": [
    {
      "metadata": "check_number: abcd1234, status: PENDING",
      "user_id": "{user_id}"
    }
  ]
}
```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
