### PR TITLE
fix: updated url to match gutenberg

### DIFF
--- a/mdx-web/src/main/java/com/mx/path/model/mdx/web/controller/RemoteDepositsController.java
+++ b/mdx-web/src/main/java/com/mx/path/model/mdx/web/controller/RemoteDepositsController.java
@@ -45,7 +45,7 @@ public class RemoteDepositsController extends BaseController {
     return new ResponseEntity<>(response.getResult().wrapped(), createMultiMapForResponse(response.getHeaders()), HttpStatus.OK);
   }
 
-  @RequestMapping(value = "/users/{userId}/accounts/remote_deposits/limits", method = RequestMethod.GET)
+  @RequestMapping(value = "/users/{userId}/remote_deposits/limits", method = RequestMethod.GET)
   public final ResponseEntity<Limits> getRemoteDepositLimits() {
     AccessorResponse<Limits> response = gateway().remoteDeposits().limits();
     return new ResponseEntity<>(response.getResult().wrapped(), createMultiMapForResponse(response.getHeaders()), HttpStatus.OK);

--- a/mdx-web/src/test/java/com/mx/testing/RemoteDepositAccessor.java
+++ b/mdx-web/src/test/java/com/mx/testing/RemoteDepositAccessor.java
@@ -5,6 +5,7 @@ import com.mx.path.gateway.accessor.AccessorResponse;
 import com.mx.path.model.mdx.accessor.remote_deposit.RemoteDepositBaseAccessor;
 import com.mx.path.model.mdx.model.MdxList;
 import com.mx.path.model.mdx.model.account.Account;
+import com.mx.path.model.mdx.model.remote_deposit.Limits;
 import com.mx.path.model.mdx.model.remote_deposit.RemoteDeposit;
 
 public class RemoteDepositAccessor extends RemoteDepositBaseAccessor {
@@ -30,5 +31,10 @@ public class RemoteDepositAccessor extends RemoteDepositBaseAccessor {
   @Override
   public AccessorResponse<MdxList<RemoteDeposit>> list() {
     return super.list();
+  }
+
+  @Override
+  public AccessorResponse<Limits> limits() {
+    return super.limits();
   }
 }


### PR DESCRIPTION
# Summary of Changes

Updated the limits url by removing '/accounts/' from the path.

Fixes # (issue)

Mismatch with gutenberg preventing mobile app from talking with path.

## Public API Additions/Changes

GetRemoteDepositLimits

## Downstream Consumer Impact

Connector-HW will need to update their Arsenal tests.

# How Has This Been Tested?

Arsenal revealed the break

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
