### PR TITLE
fix!: remove pending transactions endpoint

### DIFF
--- a/mdx-models/src/main/java/com/mx/path/model/mdx/accessor/account/TransactionBaseAccessor.java
+++ b/mdx-models/src/main/java/com/mx/path/model/mdx/accessor/account/TransactionBaseAccessor.java
@@ -113,18 +113,6 @@ public abstract class TransactionBaseAccessor extends Accessor {
   }
 
   /**
-   * List pending transactions for an account
-   *
-   * @param accountId
-   * @return
-   */
-  @GatewayAPI
-  @API(description = "List pending transactions")
-  public AccessorResponse<MdxList<Transaction>> pending(String accountId) {
-    throw new AccessorMethodNotImplementedException();
-  }
-
-  /**
    * Search paged transactions
    *
    * @param searchRequest

--- a/mdx-web/src/main/java/com/mx/path/model/mdx/web/controller/AccountsController.java
+++ b/mdx-web/src/main/java/com/mx/path/model/mdx/web/controller/AccountsController.java
@@ -101,12 +101,6 @@ public class AccountsController extends BaseController {
     return new ResponseEntity<>(response.getResult().wrapped(), createMultiMapForResponse(response.getHeaders()), HttpStatus.OK);
   }
 
-  @RequestMapping(value = "/users/{userId}/accounts/{id}/transactions/pending", method = RequestMethod.GET)
-  public final ResponseEntity<MdxList<Transaction>> pendingTransactions(@PathVariable("id") String accountId) throws Exception {
-    AccessorResponse<MdxList<Transaction>> response = gateway().accounts().transactions().pending(accountId);
-    return new ResponseEntity<>(response.getResult().wrapped(), createMultiMapForResponse(response.getHeaders()), HttpStatus.OK);
-  }
-
   @RequestMapping(value = "/users/{userId}/accounts/{id}/transactions/recent", method = RequestMethod.GET)
   public final ResponseEntity<MdxList<Transaction>> recentTransactions(@PathVariable("id") String accountId) throws Exception {
     AccessorResponse<MdxList<Transaction>> response = gateway().accounts().transactions().recent(accountId);

--- a/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/AccountsControllerTest.groovy
+++ b/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/AccountsControllerTest.groovy
@@ -186,20 +186,6 @@ class AccountsControllerTest extends Specification implements WithMockery {
     result.body == transactions
   }
 
-  def "pending transactions"() {
-    given:
-    AccountsController.setGateway(gateway)
-    MdxList<Transaction> transactions = new MdxList<Transaction>()
-
-    when:
-    Mockito.doReturn(new AccessorResponse<MdxList<Transaction>>().withResult(transactions)).when(transactionGateway).pending("A-123")
-    def result = subject.pendingTransactions("A-123")
-
-    then:
-    verify(transactionGateway).pending("A-123") || true
-    result.body == transactions
-  }
-
   def "list transactions"() {
     given:
 


### PR DESCRIPTION
# Summary of Changes

This removes the pending transactions endpoint which has already been removed from the spec in favor of using the list transactions endpoint with the status query.

# How Has This Been Tested?

Pulled this change into a connector and verified that the service could build and run

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
