### PR TITLE
fix!: grabbing accountId variable from url path

### DIFF
--- a/mdx-models/src/main/java/com/mx/path/model/mdx/accessor/account/AccountAddressBaseAccessor.java
+++ b/mdx-models/src/main/java/com/mx/path/model/mdx/accessor/account/AccountAddressBaseAccessor.java
@@ -33,60 +33,65 @@ public class AccountAddressBaseAccessor extends Accessor {
   /**
    * Create an account address
    *
+   * @param accountId
    * @param address
    * @return
    */
   @GatewayAPI
   @API(description = "Create an account address")
-  public AccessorResponse<Address> create(Address address) {
+  public AccessorResponse<Address> create(String accountId, Address address) {
     throw new AccessorMethodNotImplementedException();
   }
 
   /**
    * Delete address by id
    *
-   * @param id
+   * @param accountId
+   * @param addressId
    * @return
    */
   @GatewayAPI
   @API(description = "Delete an account address")
-  public AccessorResponse<Void> delete(String id) {
+  public AccessorResponse<Void> delete(String accountId, String addressId) {
     throw new AccessorMethodNotImplementedException();
   }
 
   /**
    * Get address by id
    *
-   * @param id
+   * @param accountId
+   * @param addressId
    * @return
    */
   @GatewayAPI
   @API(description = "Get an account address")
-  public AccessorResponse<Address> get(String id) {
+  public AccessorResponse<Address> get(String accountId, String addressId) {
     throw new AccessorMethodNotImplementedException();
   }
 
   /**
    * List addresses
    *
+   * @param accountId
    * @return
    */
   @GatewayAPI
   @API(description = "List all account addresses")
-  public AccessorResponse<MdxList<Address>> list() {
+  public AccessorResponse<MdxList<Address>> list(String accountId) {
     throw new AccessorMethodNotImplementedException();
   }
 
   /**
    * Update address
    *
-   * @param id
+   * @param accountId
+   * @param addressId
    * @param address
    * @return
    */
   @GatewayAPI
   @API(description = "Update an account address")
-  public AccessorResponse<Address> update(String id, Address address) {
+  public AccessorResponse<Address> update(String accountId, String addressId, Address address) {
     throw new AccessorMethodNotImplementedException();
   }
 

--- a/mdx-web/src/main/java/com/mx/path/model/mdx/web/controller/AccountAddressController.java
+++ b/mdx-web/src/main/java/com/mx/path/model/mdx/web/controller/AccountAddressController.java
@@ -20,34 +20,34 @@ public class AccountAddressController extends BaseController {
   }
 
   @RequestMapping(value = "/users/{user_id}/accounts/{account_id}/addresses", method = RequestMethod.GET, produces = BaseController.MDX_MEDIA)
-  public final ResponseEntity<MdxList<Address>> getAllAccountAddresses()
+  public final ResponseEntity<MdxList<Address>> getAllAccountAddresses(@PathVariable("account_id") String accountId)
       throws Exception {
-    AccessorResponse<MdxList<Address>> response = gateway().accounts().addresses().list();
+    AccessorResponse<MdxList<Address>> response = gateway().accounts().addresses().list(accountId);
     return new ResponseEntity<>(response.getResult().wrapped(), createMultiMapForResponse(response.getHeaders()), HttpStatus.OK);
   }
 
   @RequestMapping(value = "/users/{user_id}/accounts/{account_id}/addresses/{address_id}", method = RequestMethod.GET)
-  public final ResponseEntity<Address> getAccountAddress(@PathVariable("address_id") String addressId) {
-    AccessorResponse<Address> response = gateway().accounts().addresses().get(addressId);
+  public final ResponseEntity<Address> getAccountAddress(@PathVariable("account_id") String accountId, @PathVariable("address_id") String addressId) {
+    AccessorResponse<Address> response = gateway().accounts().addresses().get(accountId, addressId);
     return new ResponseEntity<>(response.getResult().wrapped(), createMultiMapForResponse(response.getHeaders()), HttpStatus.OK);
   }
 
   @RequestMapping(value = "/users/{user_id}/accounts/{account_id}/addresses/{address_id}", method = RequestMethod.DELETE)
-  public final ResponseEntity<?> deleteAccountAddress(@PathVariable("address_id") String addressId) {
-    AccessorResponse<Void> response = gateway().accounts().addresses().delete(addressId);
+  public final ResponseEntity<?> deleteAccountAddress(@PathVariable("account_id") String accountId, @PathVariable("address_id") String addressId) {
+    AccessorResponse<Void> response = gateway().accounts().addresses().delete(accountId, addressId);
     return new ResponseEntity<>(createMultiMapForResponse(response.getHeaders()), HttpStatus.NO_CONTENT);
   }
 
   @RequestMapping(value = "/users/{user_id}/accounts/{account_id}/addresses", method = RequestMethod.POST)
-  public final ResponseEntity<Address> createAccountAddress(@RequestBody Address address) {
-    AccessorResponse<Address> response = gateway().accounts().addresses().create(address);
+  public final ResponseEntity<Address> createAccountAddress(@PathVariable("account_id") String accountId, @RequestBody Address address) {
+    AccessorResponse<Address> response = gateway().accounts().addresses().create(accountId, address);
     return new ResponseEntity<>(response.getResult().wrapped(), createMultiMapForResponse(response.getHeaders()), HttpStatus.OK);
   }
 
   @RequestMapping(value = "/users/{user_id}/accounts/{account_id}/addresses/{address_id}", method = RequestMethod.PUT)
-  public final ResponseEntity<Address> updateAccountAddress(@PathVariable("address_id") String addressId, @RequestBody Address address) {
+  public final ResponseEntity<Address> updateAccountAddress(@PathVariable("account_id") String accountId, @PathVariable("address_id") String addressId, @RequestBody Address address) {
     address.setId(addressId);
-    AccessorResponse<Address> response = gateway().accounts().addresses().update(addressId, address);
+    AccessorResponse<Address> response = gateway().accounts().addresses().update(accountId, addressId, address);
     Address result = response.getResult();
     HttpStatus status = HttpStatus.OK;
     if (result.getChallenges() != null && result.getChallenges().size() > 0) {

--- a/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/AccountAddressControllerTest.groovy
+++ b/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/AccountAddressControllerTest.groovy
@@ -1,6 +1,7 @@
 package com.mx.path.model.mdx.web.controller
 
 import static org.mockito.ArgumentMatchers.any
+import static org.mockito.ArgumentMatchers.eq
 import static org.mockito.Mockito.doReturn
 import static org.mockito.Mockito.spy
 
@@ -21,6 +22,9 @@ class AccountAddressControllerTest extends Specification implements WithMockery 
   AccountAddressController subject
   Gateway gateway
   AccountAddressGateway accountAddressGateway
+
+  def accountId = '123456'
+  def addressId = '1'
 
   def setup() {
     subject = new AccountAddressController()
@@ -45,10 +49,10 @@ class AccountAddressControllerTest extends Specification implements WithMockery 
     def mockResponse = new AccessorResponse<MdxList<Address>>().withResult(new MdxList<>().tap {
       add(new Address())
     })
-    doReturn(mockResponse).when(accountAddressGateway).list()
+    doReturn(mockResponse).when(accountAddressGateway).list(accountId)
 
     when:
-    def response = subject.getAllAccountAddresses()
+    def response = subject.getAllAccountAddresses(accountId)
 
     then:
     response.body == mockResponse.result
@@ -59,10 +63,10 @@ class AccountAddressControllerTest extends Specification implements WithMockery 
   def "getAccountAddress"() {
     given:
     def mockResponse = new AccessorResponse<Address>().withResult(new Address())
-    doReturn(mockResponse).when(accountAddressGateway).get("1")
+    doReturn(mockResponse).when(accountAddressGateway).get(accountId, addressId)
 
     when:
-    def response = subject.getAccountAddress("1")
+    def response = subject.getAccountAddress(accountId, addressId)
 
     then:
     response.body == mockResponse.result
@@ -73,10 +77,10 @@ class AccountAddressControllerTest extends Specification implements WithMockery 
   def "createAccountAddress"() {
     given:
     def mockResponse = new AccessorResponse<Address>().withResult(new Address())
-    doReturn(mockResponse).when(accountAddressGateway).create(any())
+    doReturn(mockResponse).when(accountAddressGateway).create(eq(accountId), any())
 
     when:
-    def response = subject.createAccountAddress(new Address())
+    def response = subject.createAccountAddress(accountId, new Address())
 
     then:
     response.body == mockResponse.result
@@ -88,10 +92,10 @@ class AccountAddressControllerTest extends Specification implements WithMockery 
   def "updateAccountAddress - 200"() {
     given:
     def mockResponse = new AccessorResponse<Address>().withResult(new Address())
-    doReturn(mockResponse).when(accountAddressGateway).update(any(), any())
+    doReturn(mockResponse).when(accountAddressGateway).update(eq(accountId), eq(addressId), any())
 
     when:
-    def response = subject.updateAccountAddress("1", new Address())
+    def response = subject.updateAccountAddress(accountId, addressId, new Address())
 
     then:
     response.body == mockResponse.result
@@ -104,10 +108,10 @@ class AccountAddressControllerTest extends Specification implements WithMockery 
     def mockResponse = new AccessorResponse<Address>().withResult(new Address().tap {
       setChallenges(new MdxList<Challenge>().tap { add(new Challenge()) })
     })
-    doReturn(mockResponse).when(accountAddressGateway).update(any(), any())
+    doReturn(mockResponse).when(accountAddressGateway).update(eq(accountId), eq(addressId), any())
 
     when:
-    def response = subject.updateAccountAddress("1", new Address())
+    def response = subject.updateAccountAddress(accountId, addressId, new Address())
 
     then:
     response.body == mockResponse.result


### PR DESCRIPTION
# Summary of Changes

This will now leverage the accountId variable that is being passed in the url path for AccountAddress.

Fixes # (issue)

HW2-1159

## Public API Additions/Changes

AccountAddress (get, list, post, put, delete) will now find accountId variable available since it already exists in the url path.

## Downstream Consumer Impact

This will allow Path devs to grab accountId from the url instead of the address object which will be deprecated. This will add another param to the accessor so any service currently using this API that updates to the latest model will have to account for that.

# How Has This Been Tested?

AccountAddressControllerTest.groovy
Arsenal

- [ ] Test A
- [ ] Test B

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
