### PR TITLE
fix: added challenges field to authorization model

### DIFF
--- a/mdx-models/src/main/java/com/mx/path/model/mdx/model/authorization/Authorization.java
+++ b/mdx-models/src/main/java/com/mx/path/model/mdx/model/authorization/Authorization.java
@@ -1,10 +1,14 @@
 package com.mx.path.model.mdx.model.authorization;
 
+import java.util.List;
+
 import com.mx.path.model.mdx.model.MdxBase;
+import com.mx.path.model.mdx.model.challenges.Challenge;
 
 public class Authorization extends MdxBase<Authorization> {
 
   private String accountId;
+  private List<Challenge> challenges;
   private NameValuePair[] cookies;
   private String deviceId;
   private Long expiresAt;
@@ -25,6 +29,14 @@ public class Authorization extends MdxBase<Authorization> {
 
   public final void setAccountId(String newAccountId) {
     accountId = newAccountId;
+  }
+
+  public final List<Challenge> getChallenges() {
+    return challenges;
+  }
+
+  public final void setChallenges(List<Challenge> challenges) {
+    this.challenges = challenges;
   }
 
   public final NameValuePair[] getCookies() {


### PR DESCRIPTION
# Summary of Changes

Added challenges field to the Authorization model, which is already [documented here](https://developer.mx.com/drafts/mdx/authorization/#authorizations-authorization-fields).  The motivation behind this change is that the client is wanting to support prompting the user to accept terms and conditions for Zelle before proceed to use the feature.

Fixes # HW2-1135

## Public API Additions/Changes

No new classes or methods.  Just the new Authorization.challenges field.

## Downstream Consumer Impact

This shouldn't impact downstream consumers because it is just introducing a net new field.

# How Has This Been Tested?

Did not perform any tests.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation - field was already documented
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
