### PR TITLE
fix: return 202 when challenge in createAuthorization response

### DIFF
--- a/mdx-web/src/main/java/com/mx/path/model/mdx/web/controller/AuthorizationsController.java
+++ b/mdx-web/src/main/java/com/mx/path/model/mdx/web/controller/AuthorizationsController.java
@@ -22,7 +22,13 @@ public class AuthorizationsController extends BaseController {
   @RequestMapping(value = "/users/{user_id}/authorizations", method = RequestMethod.POST, consumes = BaseController.MDX_MEDIA)
   public final ResponseEntity<Authorization> createAuthorization(@RequestBody Authorization authorizationRequest) throws Exception {
     AccessorResponse<Authorization> response = gateway().authorizations().create(authorizationRequest);
-    return new ResponseEntity<>(response.getResult().wrapped(), createMultiMapForResponse(response.getHeaders()), HttpStatus.OK);
+    Authorization result = response.getResult();
+
+    HttpStatus status = HttpStatus.OK;
+    if (result.getChallenges() != null && result.getChallenges().size() > 0) {
+      status = HttpStatus.ACCEPTED;
+    }
+    return new ResponseEntity<>(response.getResult().wrapped(), createMultiMapForResponse(response.getHeaders()), status);
   }
 
   @RequestMapping(value = "/users/{user_id}/authorizations/callback", method = RequestMethod.GET, produces = "text/html")

--- a/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/AuthorizationsControllerTest.groovy
+++ b/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/AuthorizationsControllerTest.groovy
@@ -1,13 +1,17 @@
 package com.mx.path.model.mdx.web.controller
 
+import static org.mockito.Mockito.doReturn
 import static org.mockito.Mockito.spy
 import static org.mockito.Mockito.verify
 
+import com.mx.path.core.common.accessor.PathResponseStatus
 import com.mx.path.gateway.accessor.AccessorResponse
 import com.mx.path.gateway.api.Gateway
 import com.mx.path.gateway.api.authorization.AuthorizationGateway
 import com.mx.path.model.mdx.model.authorization.Authorization
 import com.mx.path.model.mdx.model.authorization.HtmlPage
+import com.mx.path.model.mdx.model.challenges.Challenge
+import com.mx.path.model.mdx.model.challenges.Question
 
 import org.mockito.Mockito
 import org.springframework.http.HttpStatus
@@ -41,6 +45,39 @@ class AuthorizationsControllerTest extends Specification {
     then:
     verify(authorizationGateway).create(authorization) || true
     HttpStatus.OK == response.getStatusCode()
+  }
+
+  def "createAuthorization - ACCEPTED"() {
+    given:
+    def authorization = new Authorization()
+    BaseController.setGateway(gateway)
+
+    def challenge = new Challenge().tap {
+      id = "CHALLENGE_1"
+      questions = new ArrayList<Question>().tap {
+        add(new Question().tap {
+          id = "QUESTION_1"
+          prompt = "Do you accept the policy?"
+          promptType = "text"
+        })
+      }
+    }
+    def accessorResponse = new Authorization().tap {
+      challenges = [challenge]
+    }
+    doReturn(new AccessorResponse<Authorization>()
+        .withResult(accessorResponse)
+        .withStatus(PathResponseStatus.ACCEPTED))
+        .when(authorizationGateway).create(authorization)
+
+    when:
+    def response = subject.createAuthorization(authorization)
+
+    then:
+    verify(gateway).authorizations() || true
+    verify(authorizationGateway).create(authorization) || true
+    response.statusCode == HttpStatus.ACCEPTED
+    response.getBody().challenges.size() > 0
   }
 
   def "callback interacts with gateway"() {


### PR DESCRIPTION
# Summary of Changes

Updated createAuthorization controller method to detect when a response contains a challenge and then sets the status code to 202.  The motivation behind this change is that the client is wanting to support prompting the user to accept terms and conditions for Zelle before proceed to use the feature.

Fixes # HW2-1135

## Public API Additions/Changes

Modified AuthorizationsController.createAuthorization() to detect challenge in response and alter status code to 202.  No method signatures were changed.

## Downstream Consumer Impact

This change should be transparent and should not impact downstream consumers.

# How Has This Been Tested?

Tested it locally with a Path connector to verify getting back a 200 or 202 as desired.  Also ran a project's authorization Arsenal tests against it to ensure they still passed.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
