### PR TITLE
fix: rename product search parameter

### DIFF
--- a/mdx-models/src/main/java/com/mx/path/model/mdx/model/products/Product.java
+++ b/mdx-models/src/main/java/com/mx/path/model/mdx/model/products/Product.java
@@ -33,8 +33,7 @@ public final class Product extends MdxBase<Product> {
 
   private String name;
 
-  @SerializedName("product_type")
-  private String productType;
+  private String type;
 
   public List<Challenge> getActivateChallenges() {
     return activateChallenges;
@@ -116,12 +115,12 @@ public final class Product extends MdxBase<Product> {
     this.name = name;
   }
 
-  public String getProductType() {
-    return productType;
+  public String getType() {
+    return type;
   }
 
-  public void setProductType(String productType) {
-    this.productType = productType;
+  public void setType(String type) {
+    this.type = type;
   }
 
 }

--- a/mdx-models/src/main/java/com/mx/path/model/mdx/model/products/ProductSearch.java
+++ b/mdx-models/src/main/java/com/mx/path/model/mdx/model/products/ProductSearch.java
@@ -7,14 +7,14 @@ package com.mx.path.model.mdx.model.products;
 @SuppressWarnings({ "checkstyle:MemberName", "checkstyle:ParameterName", "checkstyle:MethodName" })
 public class ProductSearch {
 
-  private String product_type;
+  private String type;
 
-  public final String getProduct_type() {
-    return product_type;
+  public final String getType() {
+    return type;
   }
 
-  public final void setProduct_type(String product_type) {
-    this.product_type = product_type;
+  public final void setType(String type) {
+    this.type = type;
   }
 
 }

--- a/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/ProductControllerTest.groovy
+++ b/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/ProductControllerTest.groovy
@@ -40,7 +40,7 @@ class ProductControllerTest extends Specification {
   def "listProducts interacts with gateway"() {
     given:
     def search = new ProductSearch().tap {
-      product_type = "ACCOUNT"
+      type = "ACCOUNT"
     }
     def mockResponse = new AccessorResponse<MdxList<Product>>().withResult(new MdxList<>().tap {
       add(new Product())


### PR DESCRIPTION
# Summary of Changes

Rename product search parameter from and field `product_type` to `type`

## Public API Additions/Changes

Product.java
ProductSearch.java

## Downstream Consumer Impact

This shouldn't impact downstream consumers because it is a new implementation

# How Has This Been Tested?

No test needed.

- [ ] Test A
- [ ] Test B

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
