### PR TITLE
feat: rename insured_status to federal_insurance_status and deprecate old field

### DIFF
--- a/mdx-models/src/main/java/com/mx/path/model/mdx/model/account/Account.java
+++ b/mdx-models/src/main/java/com/mx/path/model/mdx/model/account/Account.java
@@ -33,6 +33,8 @@ public class Account extends MdxBase<Account> {
   private String currencyCode;
   @XmlElement(name = "day_payment_is_due")
   private LocalDate dayPaymentIsDue;
+  @XmlElement(name = "federal_insurance_status")
+  private String federalInsuranceStatus;
   @XmlElement(name = "guid")
   private String guid;
   @XmlElement(name = "has_monthly_transfer_limit")
@@ -108,8 +110,6 @@ public class Account extends MdxBase<Account> {
   private String subtype;
   @XmlElement(name = "type")
   private String type;
-  @XmlElement(name = "insured_status")
-  private String insuredStatus;
 
   // --------------------------------------------------------
   // Internal Fields
@@ -221,6 +221,14 @@ public class Account extends MdxBase<Account> {
     this.dayPaymentIsDue = newDayPaymentIsDue;
   }
 
+  public final String getFederalInsuranceStatus() {
+    return federalInsuranceStatus;
+  }
+
+  public final void setFederalInsuranceStatus(String federalInsuranceStatus) {
+    this.federalInsuranceStatus = federalInsuranceStatus;
+  }
+
   public final String getGuid() {
     return guid;
   }
@@ -251,6 +259,22 @@ public class Account extends MdxBase<Account> {
 
   public final void setId(String newId) {
     this.id = newId;
+  }
+
+  /**
+   * @deprecated Use {@link #getFederalInsuranceStatus()} instead.
+   */
+  @Deprecated
+  public final String getInsuredStatus() {
+    return federalInsuranceStatus;
+  }
+
+  /**
+   * @deprecated Use {@link #setFederalInsuranceStatus(String)} instead.
+   */
+  @Deprecated
+  public final void setInsuredStatus(String insuredStatus) {
+    this.federalInsuranceStatus = insuredStatus;
   }
 
   public final Double getInterestRate() {
@@ -515,14 +539,6 @@ public class Account extends MdxBase<Account> {
 
   public final void setType(String newType) {
     this.type = newType;
-  }
-
-  public final String getInsuredStatus() {
-    return insuredStatus;
-  }
-
-  public final void setInsuredStatus(String insuredStatus) {
-    this.insuredStatus = insuredStatus;
   }
 
   // Internal Fields


### PR DESCRIPTION
# Summary of Changes

We need to rename this field for clarity. Renaming property but deprecating and leaving getter/setter in place. They both point at the new property.

