### PR TITLE
feat: added challenges to remote deposit object

### DIFF
--- a/mdx-models/src/main/java/com/mx/path/model/mdx/model/remote_deposit/RemoteDeposit.java
+++ b/mdx-models/src/main/java/com/mx/path/model/mdx/model/remote_deposit/RemoteDeposit.java
@@ -160,7 +160,11 @@ public final class RemoteDeposit extends MdxBase<RemoteDeposit> {
     this.updatedOn = newUpdatedOn;
   }
 
-  public List<Challenge> getChallenges() { return challenges; }
+  public List<Challenge> getChallenges() {
+    return challenges;
+  }
 
-  public void setChallenges(List<Challenge> newChallenges) { this.challenges = newChallenges; }
+  public void setChallenges(List<Challenge> newChallenges) {
+    this.challenges = newChallenges;
+  }
 }

--- a/mdx-models/src/main/java/com/mx/path/model/mdx/model/remote_deposit/RemoteDeposit.java
+++ b/mdx-models/src/main/java/com/mx/path/model/mdx/model/remote_deposit/RemoteDeposit.java
@@ -1,11 +1,13 @@
 package com.mx.path.model.mdx.model.remote_deposit;
 
 import java.time.LocalDate;
+import java.util.List;
 
 import com.google.gson.annotations.SerializedName;
 import com.mx.path.model.mdx.model.MdxBase;
 import com.mx.path.model.mdx.model.MdxRelationId;
 import com.mx.path.model.mdx.model.account.Account;
+import com.mx.path.model.mdx.model.challenges.Challenge;
 
 public final class RemoteDeposit extends MdxBase<RemoteDeposit> {
   @SerializedName("account_id")
@@ -27,6 +29,7 @@ public final class RemoteDeposit extends MdxBase<RemoteDeposit> {
   private String status;
   private Long updatedAt;
   private LocalDate updatedOn;
+  private List<Challenge> challenges;
 
   @MdxRelationId(referredClass = Account.class)
   public String getAccountId() {
@@ -156,4 +159,8 @@ public final class RemoteDeposit extends MdxBase<RemoteDeposit> {
   public void setUpdatedOn(LocalDate newUpdatedOn) {
     this.updatedOn = newUpdatedOn;
   }
+
+  public List<Challenge> getChallenges() { return challenges; }
+
+  public void setChallenges(List<Challenge> newChallenges) { this.challenges = newChallenges; }
 }

--- a/mdx-web/src/main/java/com/mx/path/model/mdx/web/controller/RemoteDepositsController.java
+++ b/mdx-web/src/main/java/com/mx/path/model/mdx/web/controller/RemoteDepositsController.java
@@ -24,7 +24,12 @@ public class RemoteDepositsController extends BaseController {
   @RequestMapping(value = "/users/{user_id}/remote_deposits", method = RequestMethod.POST, consumes = MDX_MEDIA)
   public final ResponseEntity<RemoteDeposit> createRemoteDeposit(@RequestBody RemoteDeposit remoteDepositRequest) {
     AccessorResponse<RemoteDeposit> response = gateway().remoteDeposits().create(remoteDepositRequest);
-    return new ResponseEntity<>(response.getResult().wrapped(), createMultiMapForResponse(response.getHeaders()), HttpStatus.OK);
+    RemoteDeposit result = response.getResult();
+    HttpStatus status = HttpStatus.OK;
+    if (result != null && result.getChallenges() != null && !result.getChallenges().isEmpty()) {
+      status = HttpStatus.ACCEPTED;
+    }
+    return new ResponseEntity<>(response.getResult().wrapped(), createMultiMapForResponse(response.getHeaders()), status);
   }
 
   @RequestMapping(value = "/users/{userId}/remote_deposits/{id}", method = RequestMethod.GET)

--- a/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/RemoteDepositsControllerTest.groovy
+++ b/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/RemoteDepositsControllerTest.groovy
@@ -1,5 +1,7 @@
 package com.mx.path.model.mdx.web.controller
 
+import static org.mockito.ArgumentMatchers.any
+import static org.mockito.Mockito.doReturn
 import static org.mockito.Mockito.spy
 import static org.mockito.Mockito.verify
 
@@ -8,6 +10,7 @@ import com.mx.path.gateway.api.Gateway
 import com.mx.path.gateway.api.remote_deposit.RemoteDepositGateway
 import com.mx.path.model.mdx.model.MdxList
 import com.mx.path.model.mdx.model.account.Account
+import com.mx.path.model.mdx.model.challenges.Challenge
 import com.mx.path.model.mdx.model.remote_deposit.Limits
 import com.mx.path.model.mdx.model.remote_deposit.RemoteDeposit
 
@@ -62,6 +65,24 @@ class RemoteDepositsControllerTest extends Specification {
     verify(remoteDepositGateway).list() || true
     HttpStatus.OK == response.getStatusCode()
     response.getBody() == list
+  }
+
+  def "createRemoteDeposit - 202"() {
+    given:
+    BaseController.setGateway(gateway)
+
+    def mockResponse = new AccessorResponse<RemoteDeposit>().withResult(new RemoteDeposit().tap {
+      setChallenges(new MdxList<Challenge>().tap { add(new Challenge()) })
+    })
+    doReturn(mockResponse).when(remoteDepositGateway).create(any())
+
+    when:
+    def response = subject.createRemoteDeposit(new RemoteDeposit())
+
+    then:
+    response.body == mockResponse.result
+    response.body.wrapped
+    response.statusCode == HttpStatus.ACCEPTED
   }
 
   def "createRemoteDeposit interacts with gateway"() {


### PR DESCRIPTION
# Summary of Changes

Added challenges to remote deposit object. This is to satisfy the spec changes for remote deposit fields update. To be used mainly for the response object on the create endpoint.

Fixes # (issue)
To allow for confirmable options when submitting a remote deposit and the user can correct any outstanding issues or move forward with the submission.
https://mxcom.atlassian.net/browse/HW2-1592
https://developer.mx.com/drafts/mdx/remote_deposit/index.html#remote-deposits-remote-deposit-fields

## Public API Additions/Changes

This updates the request object for:

- Create

This updates the response object for:

- Create
- Get
- List 

## Downstream Consumer Impact

No breaking changes.
This will apply to any connector using Ensenta that wish to take advantage of the Confirmable option allowing users to choose to update their remote deposits.

# How Has This Been Tested?

Testing in path-connector-hancock-whitney has shown this is a viable solution.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
