### PR TITLE
fix!: remove custom variables for hw that are not needed

### DIFF
--- a/mdx-models/src/main/java/com/mx/path/model/mdx/model/account/Account.java
+++ b/mdx-models/src/main/java/com/mx/path/model/mdx/model/account/Account.java
@@ -31,10 +31,6 @@ public class Account extends MdxBase<Account> {
   private BigDecimal creditLimit;
   @XmlElement(name = "currency_code")
   private String currencyCode;
-  @XmlElement(name = "daily_deposit_limit_current")
-  private Double dailyDepositLimitCurrent;
-  @XmlElement(name = "daily_deposit_limit_total")
-  private Double dailyDepositLimitTotal;
   @XmlElement(name = "day_payment_is_due")
   private LocalDate dayPaymentIsDue;
   @XmlElement(name = "guid")
@@ -45,10 +41,6 @@ public class Account extends MdxBase<Account> {
   private BigDecimal holdTotal;
   @XmlElement(name = "id")
   private String id;
-  @XmlElement(name = "interest_paid_previous_year")
-  private Double interestPaidPreviousYear;
-  @XmlElement(name = "interest_paid_ytd")
-  private Double interestPaidYtd;
   @XmlElement(name = "interest_rate")
   private Double interestRate;
   @XmlElement(name = "is_closed")
@@ -63,10 +55,6 @@ public class Account extends MdxBase<Account> {
   private LocalDate lastPaymentOn;
   @XmlElement(name = "loan_amount")
   private BigDecimal loanAmount;
-  @XmlElement(name = "monthly_deposit_limit_current")
-  private Double monthlyDepositLimitCurrent;
-  @XmlElement(name = "monthly_deposit_limit_total")
-  private Double monthlyDepositLimitTotal;
   @XmlElement(name = "matures_at")
   private Long maturesAt;
   @XmlElement(name = "matures_on")
@@ -87,8 +75,6 @@ public class Account extends MdxBase<Account> {
   private String name;
   @XmlElement(name = "nickname")
   private String nickname;
-  @XmlElement(name = "next_payment")
-  private Double nextPayment;
   @XmlElement(name = "original_balance")
   private BigDecimal originalBalance;
   @XmlElement(name = "past_due_amount")
@@ -105,8 +91,6 @@ public class Account extends MdxBase<Account> {
   private BigDecimal pendingBalance;
   @XmlElement(name = "pending_transactions_total")
   private BigDecimal pendingTransactionsTotal;
-  @XmlElement(name = "principal_balance")
-  private Double principalBalance;
   @XmlElement(name = "routing_number")
   private String routingNumber;
   @Deprecated
@@ -120,8 +104,6 @@ public class Account extends MdxBase<Account> {
   private BigDecimal statementBalance;
   @XmlElement(name = "statement_closed_on")
   private LocalDate statementClosedOn;
-  @XmlElement(name = "statement_late_charges")
-  private Double statementLateCharges;
   @XmlElement(name = "subtype")
   private String subtype;
   @XmlElement(name = "type")
@@ -231,22 +213,6 @@ public class Account extends MdxBase<Account> {
     this.currencyCode = newCurrencyCode;
   }
 
-  public final Double getDailyDepositLimitCurrent() {
-    return dailyDepositLimitCurrent;
-  }
-
-  public final void setDailyDepositLimitCurrent(Double dailyDepositLimitCurrent) {
-    this.dailyDepositLimitCurrent = dailyDepositLimitCurrent;
-  }
-
-  public final Double getDailyDepositLimitTotal() {
-    return dailyDepositLimitTotal;
-  }
-
-  public final void setDailyDepositLimitTotal(Double dailyDepositLimitTotal) {
-    this.dailyDepositLimitTotal = dailyDepositLimitTotal;
-  }
-
   public final LocalDate getDayPaymentIsDue() {
     return dayPaymentIsDue;
   }
@@ -285,22 +251,6 @@ public class Account extends MdxBase<Account> {
 
   public final void setId(String newId) {
     this.id = newId;
-  }
-
-  public final Double getInterestPaidPreviousYear() {
-    return interestPaidPreviousYear;
-  }
-
-  public final void setInterestPaidPreviousYear(Double interestPaidPreviousYear) {
-    this.interestPaidPreviousYear = interestPaidPreviousYear;
-  }
-
-  public final Double getInterestPaidYtd() {
-    return interestPaidYtd;
-  }
-
-  public final void setInterestPaidYtd(Double interestPaidYtd) {
-    this.interestPaidYtd = interestPaidYtd;
   }
 
   public final Double getInterestRate() {
@@ -357,22 +307,6 @@ public class Account extends MdxBase<Account> {
 
   public final void setLoanAmount(BigDecimal loanAmount) {
     this.loanAmount = loanAmount;
-  }
-
-  public final Double getMonthlyDepositLimitCurrent() {
-    return monthlyDepositLimitCurrent;
-  }
-
-  public final void setMonthlyDepositLimitCurrent(Double monthlyDepositLimitCurrent) {
-    this.monthlyDepositLimitCurrent = monthlyDepositLimitCurrent;
-  }
-
-  public final Double getMonthlyDepositLimitTotal() {
-    return monthlyDepositLimitTotal;
-  }
-
-  public final void setMonthlyDepositLimitTotal(Double monthlyDepositLimitTotal) {
-    this.monthlyDepositLimitTotal = monthlyDepositLimitTotal;
   }
 
   public final Long getMaturesAt() {
@@ -455,14 +389,6 @@ public class Account extends MdxBase<Account> {
     this.nickname = newNickname;
   }
 
-  public final Double getNextPayment() {
-    return nextPayment;
-  }
-
-  public final void setNextPayment(Double nextPayment) {
-    this.nextPayment = nextPayment;
-  }
-
   public final BigDecimal getOriginalBalance() {
     return originalBalance;
   }
@@ -527,14 +453,6 @@ public class Account extends MdxBase<Account> {
     this.pendingTransactionsTotal = pendingTransactionsTotal;
   }
 
-  public final Double getPrincipalBalance() {
-    return principalBalance;
-  }
-
-  public final void setPrincipalBalance(Double principalBalance) {
-    this.principalBalance = principalBalance;
-  }
-
   public final String getRoutingNumber() {
     return routingNumber;
   }
@@ -581,14 +499,6 @@ public class Account extends MdxBase<Account> {
 
   public final void setStatementClosedOn(LocalDate newStatementClosedOn) {
     this.statementClosedOn = newStatementClosedOn;
-  }
-
-  public final Double getStatementLateCharges() {
-    return statementLateCharges;
-  }
-
-  public final void setStatementLateCharges(Double statementLateCharges) {
-    this.statementLateCharges = statementLateCharges;
   }
 
   public final String getSubtype() {

--- a/mdx-models/src/main/java/com/mx/path/model/mdx/model/account/StopPayment.java
+++ b/mdx-models/src/main/java/com/mx/path/model/mdx/model/account/StopPayment.java
@@ -1,5 +1,7 @@
 package com.mx.path.model.mdx.model.account;
 
+import java.time.LocalDate;
+
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
@@ -9,6 +11,7 @@ import com.mx.path.model.mdx.model.MdxBase;
 @Data
 public class StopPayment extends MdxBase<StopPayment> {
   private Double amount;
+  private LocalDate effectiveOn;
   private String endingCheckNumber;
   private Double fee;
   private String id;

--- a/mdx-models/src/main/java/com/mx/path/model/mdx/model/account/StopPayment.java
+++ b/mdx-models/src/main/java/com/mx/path/model/mdx/model/account/StopPayment.java
@@ -1,7 +1,5 @@
 package com.mx.path.model.mdx.model.account;
 
-import java.time.LocalDate;
-
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
@@ -11,7 +9,6 @@ import com.mx.path.model.mdx.model.MdxBase;
 @Data
 public class StopPayment extends MdxBase<StopPayment> {
   private Double amount;
-  private LocalDate effectiveOn;
   private String endingCheckNumber;
   private Double fee;
   private String id;

--- a/mdx-models/src/test/groovy/com/mx/path/extensions/StringStaticExtension.groovy
+++ b/mdx-models/src/test/groovy/com/mx/path/extensions/StringStaticExtension.groovy
@@ -1,0 +1,12 @@
+package com.mx.path.extensions
+
+class StringStaticExtension {
+
+  static String sanitizeXml(final StringWriter self) {
+    sanitizeXml(self.toString())
+  }
+
+  static String sanitizeXml(final String self) {
+    self.replaceAll("\n","").replaceAll("\r","").replaceAll("\t","").replaceAll(">\\s+<", "")
+  }
+}

--- a/mdx-models/src/test/groovy/com/mx/path/model/mdx/model/ondemand/MdxOnDemandMdxListSerializerTest.groovy
+++ b/mdx-models/src/test/groovy/com/mx/path/model/mdx/model/ondemand/MdxOnDemandMdxListSerializerTest.groovy
@@ -1,5 +1,7 @@
 package com.mx.path.model.mdx.model.ondemand
 
+import static com.mx.path.extensions.StringStaticExtension.sanitizeXml
+
 import com.fasterxml.jackson.core.JsonGenerator
 import com.fasterxml.jackson.databind.SerializerProvider
 import com.fasterxml.jackson.dataformat.xml.XmlFactory
@@ -52,12 +54,14 @@ class MdxOnDemandMdxListSerializerTest extends Specification implements WithMock
     generator.flush()
 
     then:
-    stringWriter.toString() == "<Transaction>\n" +
+    def expectedResponse= "<Transaction>\n" +
         "  <wrapped>false</wrapped>\n" +
         "  <amount>9.99</amount>\n" +
         "  <description>Fees</description>\n" +
         "  <id>T-123</id>\n" +
         "</Transaction>\n"
+
+    sanitizeXml(stringWriter) == sanitizeXml(expectedResponse)
   }
 
   def "wrapper name, empty interacts with generator"() {
@@ -83,9 +87,11 @@ class MdxOnDemandMdxListSerializerTest extends Specification implements WithMock
     generator.flush()
 
     then:
-    stringWriter.toString() == "<mdx version=\"5.0\">\n" +
+    def expectedResponse= "<mdx version=\"5.0\">\n" +
         "<transactions>\n</transactions>\n" +
         "</mdx>\n"
+
+    sanitizeXml(stringWriter) == sanitizeXml(expectedResponse)
   }
 
   def "wraps list interacts with generator"() {
@@ -108,7 +114,7 @@ class MdxOnDemandMdxListSerializerTest extends Specification implements WithMock
     generator.flush()
 
     then:
-    stringWriter.toString() == "<mdx version=\"5.0\">\n" +
+    def expectedResponse= "<mdx version=\"5.0\">\n" +
         "<transactions>\n" +
         "<Transaction>\n" +
         "  <wrapped>false</wrapped>\n" +
@@ -124,6 +130,8 @@ class MdxOnDemandMdxListSerializerTest extends Specification implements WithMock
         "</Transaction>\n" +
         "</transactions>\n" +
         "</mdx>\n"
+
+    sanitizeXml(stringWriter) == sanitizeXml(expectedResponse)
   }
 
   def "wraps list interacts with generator applies mixins"() {
@@ -149,7 +157,7 @@ class MdxOnDemandMdxListSerializerTest extends Specification implements WithMock
     subject.serialize(list, (JsonGenerator) generator, (SerializerProvider) null)
 
     then:
-    stringWriter.toString() == "<mdx version=\"5.0\">\n" +
+    def expectedResponse= "<mdx version=\"5.0\">\n" +
         "<accounts>\n" +
         "<account>\n" +
         "  <balance>9.99</balance>\n" +
@@ -161,5 +169,7 @@ class MdxOnDemandMdxListSerializerTest extends Specification implements WithMock
         "</account>\n"
     "</accounts>\n" +
         "</mdx>\n"
+
+    sanitizeXml(stringWriter) == sanitizeXml(expectedResponse)
   }
 }

--- a/mdx-models/src/test/groovy/com/mx/path/model/mdx/model/ondemand/MdxOnDemandSerializerTest.groovy
+++ b/mdx-models/src/test/groovy/com/mx/path/model/mdx/model/ondemand/MdxOnDemandSerializerTest.groovy
@@ -1,5 +1,7 @@
 package com.mx.path.model.mdx.model.ondemand
 
+import static com.mx.path.extensions.StringStaticExtension.sanitizeXml
+
 import java.time.LocalDate
 
 import com.fasterxml.jackson.core.JsonGenerator
@@ -47,12 +49,14 @@ class MdxOnDemandSerializerTest extends Specification implements WithMockery {
     generator.flush()
 
     then:
-    stringWriter.toString() == "<Account>\n" +
+    def expectedResponse = "<Account>\n" +
         "  <wrapped>false</wrapped>\n" +
         "  <balance>0.09</balance>\n" +
         "  <id>A-123</id>\n" +
         "  <name>Checking</name>\n" +
         "</Account>\n"
+
+    sanitizeXml(stringWriter) == sanitizeXml(expectedResponse)
   }
 
   def "wrapped, interacts with generator"() {
@@ -69,7 +73,7 @@ class MdxOnDemandSerializerTest extends Specification implements WithMockery {
     generator.flush()
 
     then:
-    stringWriter.toString() == "<mdx version=\"5.0\">\n" +
+    def expectedResponse = "<mdx version=\"5.0\">\n" +
         "<Account>\n" +
         "  <wrapped>true</wrapped>\n" +
         "  <balance>0.09</balance>\n" +
@@ -77,6 +81,8 @@ class MdxOnDemandSerializerTest extends Specification implements WithMockery {
         "  <name>Checking</name>\n" +
         "</Account>\n" +
         "</mdx>\n"
+
+    sanitizeXml(stringWriter) == sanitizeXml(expectedResponse)
   }
 
   def "applies mixins"() {
@@ -96,7 +102,7 @@ class MdxOnDemandSerializerTest extends Specification implements WithMockery {
     generator.flush()
 
     then:
-    stringWriter.toString() == "<mdx version=\"5.0\">\n" +
+    def expectedResponse = "<mdx version=\"5.0\">\n" +
         "<account>\n" +
         "  <balance>0.09</balance>\n" +
         "  <id>A-123</id>\n" +
@@ -104,6 +110,8 @@ class MdxOnDemandSerializerTest extends Specification implements WithMockery {
         "  <payment_due_on>2020-12-05</payment_due_on>\n" +
         "</account>\n" +
         "</mdx>\n"
+
+    sanitizeXml(stringWriter) == sanitizeXml(expectedResponse)
   }
 
   def "accounts list mixins"() {
@@ -135,7 +143,7 @@ class MdxOnDemandSerializerTest extends Specification implements WithMockery {
     generator.flush()
 
     then:
-    stringWriter.toString() == "<mdx version=\"5.0\">\n" +
+    def expectedResponse = "<mdx version=\"5.0\">\n" +
         "<accounts>\n" +
         "  <account>\n" +
         "    <balance>0.09</balance>\n" +
@@ -151,6 +159,8 @@ class MdxOnDemandSerializerTest extends Specification implements WithMockery {
         "  </account>\n" +
         "</accounts>\n" +
         "</mdx>\n"
+
+    sanitizeXml(stringWriter) == sanitizeXml(expectedResponse)
   }
 
   def "empty accounts list mixins"() {
@@ -167,9 +177,11 @@ class MdxOnDemandSerializerTest extends Specification implements WithMockery {
     generator.flush()
 
     then:
-    stringWriter.toString() == "<mdx version=\"5.0\">\n" +
+    def expectedResponse = "<mdx version=\"5.0\">\n" +
         "<accounts/>\n" +
         "</mdx>\n"
+
+    sanitizeXml(stringWriter) == sanitizeXml(expectedResponse)
   }
 
   def "serializes LocalDate to string"() {
@@ -183,10 +195,12 @@ class MdxOnDemandSerializerTest extends Specification implements WithMockery {
     generator.flush()
 
     then:
-    stringWriter.toString() == "<Transaction>\n" +
+    def expectedResponse = "<Transaction>\n" +
         "  <wrapped>false</wrapped>\n" +
         "  <posted_on>2020-01-12</posted_on>\n" +
         "</Transaction>\n"
+
+    sanitizeXml(stringWriter) == sanitizeXml(expectedResponse)
   }
 
   def "serializes large amounts"() {
@@ -204,7 +218,7 @@ class MdxOnDemandSerializerTest extends Specification implements WithMockery {
     generator.flush()
 
     then:
-    stringWriter.toString() == "<mdx version=\"5.0\">\n" +
+    def expectedResponse = "<mdx version=\"5.0\">\n" +
         "<Account>\n" +
         "  <wrapped>true</wrapped>\n" +
         "  <balance>30000000.00</balance>\n" +
@@ -212,5 +226,7 @@ class MdxOnDemandSerializerTest extends Specification implements WithMockery {
         "  <name>Checking</name>\n" +
         "</Account>\n" +
         "</mdx>\n"
+
+    sanitizeXml(stringWriter) == sanitizeXml(expectedResponse)
   }
 }


### PR DESCRIPTION
# Summary of Changes

Match spec changes:
https://gitlab.mx.com/mx/gutenberg/-/merge_requests/871

9 custom variables were added to Account for HW that are no longer needed, so they are being removed. Along with a custom variable for StopPayment.

Fixes # (issue)

https://mxcom.atlassian.net/browse/HW2-493

## Public API Additions/Changes

Anything related to Account.

## Downstream Consumer Impact

This will only break the HW connector, which I will handle myself.

# How Has This Been Tested?

- [ ] Test A
- [ ] Test B

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
