### PR TITLE
fix: removed consumes mdx-media CrossAccountRecurringTransferController

### DIFF
--- a/mdx-web/src/main/java/com/mx/path/model/mdx/web/controller/CrossAccountRecurringTransferController.java
+++ b/mdx-web/src/main/java/com/mx/path/model/mdx/web/controller/CrossAccountRecurringTransferController.java
@@ -48,7 +48,7 @@ public class CrossAccountRecurringTransferController extends BaseController {
     return new ResponseEntity<>(createMultiMapForResponse(response.getHeaders()), HttpStatus.NO_CONTENT);
   }
 
-  @RequestMapping(value = "/users/{userId}/cross_account_transfers/recurring_cross_account_transfers/{id}/skip_next", method = RequestMethod.PUT, consumes = MDX_MEDIA)
+  @RequestMapping(value = "/users/{userId}/cross_account_transfers/recurring_cross_account_transfers/{id}/skip_next", method = RequestMethod.PUT)
   public final ResponseEntity<?> skipCrossAccountRecurringTransfer(@PathVariable("id") String recurringTransferId) {
     AccessorResponse<CrossAccountRecurringTransfer> response = gateway().crossAccount().crossAccountRecurring().skipNext(recurringTransferId);
     return new ResponseEntity<>(createMultiMapForResponse(response.getHeaders()), HttpStatus.NO_CONTENT);


### PR DESCRIPTION
# Summary of Changes

Removing `consumes = MDX_MEDIA` from skipRecurringCrossAccountTransfer. This is fix was already applied to RecurringTransferController in the past. It has been causing issues with AFCU recxfers.

Fixes # https://mxcom.atlassian.net/browse/AFCU-241

## Downstream Consumer Impact

No longer limits media type to only include MDX_MEDIA.

# How Has This Been Tested?

Arsenal test runs have been performed locally against this change, including skip next recurring transfer which is what this change is directly affecting.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
