### PR TITLE
fix: avoid modifying the response after it has been already committed

### DIFF
--- a/mdx-web/src/main/java/com/mx/path/model/mdx/web/filter/ErrorHandler.java
+++ b/mdx-web/src/main/java/com/mx/path/model/mdx/web/filter/ErrorHandler.java
@@ -98,10 +98,16 @@ class ErrorHandler {
           ExceptionFormatter.convertToPathRequestException(ex, response));
     }
 
-    // Temporarily put back error response writer.
-    // This fails when a filter fails.
-    //    HttpServletResponse resp = response;
-    response.reset();
+    try {
+      if (!response.isCommitted()) {
+        response.reset();
+      }
+    } catch (IllegalStateException ignored) {
+      // Ignoring the exception since the response has been already committed
+      LOGGER.warn("Response already committed, cannot reset or modify.");
+      return;
+    }
+
     response.setStatus(status.value());
     response.setContentType("application/vnd.mx.mdx.v6+json");
 


### PR DESCRIPTION
# Summary of Changes

There is an issue calling reset on the response, causing the original exception to be masked.
```
java.lang.IllegalStateException: Cannot call reset() after response has been committed
	at org.apache.catalina.connector.ResponseFacade.checkCommitted(ResponseFacade.java:511)
	at org.apache.catalina.connector.ResponseFacade.reset(ResponseFacade.java:277)
	at com.mx.path.model.mdx.web.filter.ErrorHandler.handleException(ErrorHandler.java:104)
	at com.mx.path.model.mdx.web.filter.ErrorHandlerFilter.doFilterInternal(ErrorHandlerFilter.java:34)
```


The `IllegalStateException` occurs because the response object has already been committed.
Calling response.reset() after the response is committed results in this exception.

To avoid this, now we check if the response  is committed before resetting

If response might already be committed, you could log the exception instead and avoid trying to modify the response headers and body further. Here’s how it might look:

Fixes MC-3682) ([issue](https://mxcom.atlassian.net/browse/MC-3682))

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
