### PR TITLE
BREAKING CHANGE: restore interest_paid_previous_year and interest_paid_ytd

### DIFF
--- a/mdx-models/src/main/java/com/mx/path/model/mdx/model/account/Account.java
+++ b/mdx-models/src/main/java/com/mx/path/model/mdx/model/account/Account.java
@@ -43,6 +43,10 @@ public class Account extends MdxBase<Account> {
   private BigDecimal holdTotal;
   @XmlElement(name = "id")
   private String id;
+  @XmlElement(name = "interest_paid_previous_year")
+  private Double interestPaidPreviousYear;
+  @XmlElement(name = "interest_paid_ytd")
+  private Double interestPaidYtd;
   @XmlElement(name = "interest_rate")
   private Double interestRate;
   @XmlElement(name = "is_closed")
@@ -275,6 +279,22 @@ public class Account extends MdxBase<Account> {
   @Deprecated
   public final void setInsuredStatus(String insuredStatus) {
     this.federalInsuranceStatus = insuredStatus;
+  }
+
+  public final Double getInterestPaidPreviousYear() {
+    return interestPaidPreviousYear;
+  }
+
+  public final void setInterestPaidPreviousYear(Double newInterestPaidPreviousYear) {
+    this.interestPaidPreviousYear = newInterestPaidPreviousYear;
+  }
+
+  public final Double getInterestPaidYtd() {
+    return interestPaidYtd;
+  }
+
+  public final void setInterestPaidYtd(Double newInterestPaidYtd) {
+    this.interestPaidYtd = newInterestPaidYtd;
   }
 
   public final Double getInterestRate() {

--- a/mdx-models/src/main/java/com/mx/path/model/mdx/model/account/CoreFields.java
+++ b/mdx-models/src/main/java/com/mx/path/model/mdx/model/account/CoreFields.java
@@ -17,8 +17,6 @@ public class CoreFields extends MdxBase<CoreFields> {
   private Boolean hasCashSurrenderValue;
   private Boolean hasCreditLimit;
   private Boolean hasCurrencyCode;
-  private Boolean hasDailyDepositLimitCurrent;
-  private Boolean hasDailyDepositLimitTotal;
   private Boolean hasDayPaymentIsDue;
   private Boolean hasDeathBenefit;
   private Boolean hasMonthlyTransferLimit;
@@ -38,10 +36,7 @@ public class CoreFields extends MdxBase<CoreFields> {
   private Boolean hasMinimumBalance;
   private Boolean hasMinimumPayment;
   private Boolean hasMonthlyTransferCount;
-  private Boolean hasMonthlyDepositLimitCurrent;
-  private Boolean hasMonthlyDepositLimitTotal;
   private Boolean hasName;
-  private Boolean hasNextPayment;
   private Boolean hasNickname;
   private Boolean hasOriginalBalance;
   private Boolean hasPastDueAmount;
@@ -52,10 +47,8 @@ public class CoreFields extends MdxBase<CoreFields> {
   private Boolean hasPendingBalance;
   private Boolean hasPendingTransactionsTotal;
   private Boolean hasPremiumAmount;
-  private Boolean hasPrincipalBalance;
   private Boolean hasRoutingNumber;
   private Boolean hasStartedDate;
-  private Boolean hasStatementBalance;
   private Boolean hasStatementClosedOn;
   private Boolean hasStatementLateCharges;
   private Boolean hasSubtype;


### PR DESCRIPTION
# Summary of Changes
Updates Account and Account Details objects to match the spec

Fixes [MC-4089](https://mxcom.atlassian.net/browse/MC-4089)

## Public API Additions/Changes
- restore Account fields `interest_paid_previous_year` and `interest_paid_ytd`
- remove unused AccountDetails fields `has_daily_deposit_limit_current`, `has_daily_deposit_limit_total`, `has_monthly_deposit_limit_current`, `has_monthly_deposit_limit_total`, `has_next_payment`, `has_principal_balance` and `has_statement_balance`

## Downstream Consumer Impact

Removed AccountDetail fields are a breaking change

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works


[MC-4089]: https://mxcom.atlassian.net/browse/MC-4089?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ