### PR TITLE
fix: replace phone strings with list of phones for remote user

### DIFF
--- a/mdx-models/src/main/java/com/mx/path/api/connect/messaging/remote/models/RemoteUser.java
+++ b/mdx-models/src/main/java/com/mx/path/api/connect/messaging/remote/models/RemoteUser.java
@@ -1,8 +1,11 @@
 package com.mx.path.connect.messaging.remote.models;
 
+import java.util.List;
+
 import lombok.Data;
 
 import com.mx.path.model.mdx.model.MdxBase;
+import com.mx.path.model.mdx.model.profile.Phone;
 
 @Data
 public class RemoteUser extends MdxBase<RemoteUser> {
@@ -19,9 +22,7 @@ public class RemoteUser extends MdxBase<RemoteUser> {
   private String firstName;
   private String lastName;
   private String phone;
-  private String homePhone;
-  private String mobilePhone;
-  private String workPhone;
+  private List<Phone> phones;
   private Boolean remoteDepositEligible;
   private Boolean remoteDepositEnrolled;
   private String ssn;


### PR DESCRIPTION
# Summary of Changes

Reverts these changes I made the other day https://github.com/mxenabled/path-mdx-model/pull/273. And replaces with a list of phones. Requirements changed and we need to return multiple of the same phone type. A list of phones allows that. 

# How Has This Been Tested?

I pulled this into gcu and verified it works correctly with NATs calls

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
