### PR TITLE
feat: add hasCardRewards field to account details features

### DIFF
--- a/mdx-models/src/main/java/com/mx/path/model/mdx/model/account/Features.java
+++ b/mdx-models/src/main/java/com/mx/path/model/mdx/model/account/Features.java
@@ -9,6 +9,7 @@ import com.mx.path.model.mdx.model.MdxBase;
 @Data
 public class Features extends MdxBase<Features> {
   private Boolean hasCardManager;
+  private Boolean hasCardRewards;
   private Boolean hasCheckReorder;
   private Boolean hasDirectDepositManagement;
   private Boolean hasEditAddress;


### PR DESCRIPTION
# Summary of Changes

We have a requirement to control the display of a rewards feature based on whether a credit card is eligible for rewards.  Thus I have added the `hasCardRewards` field to the account details features per the [documentation here](https://developer.mx.com/drafts/mdx/accounts/#accounts-account-details-additional).

Fixes # HW2-1747

## Public API Additions/Changes

Added the `hasCardRewards` field to account details features.

## Downstream Consumer Impact

This shouldn't affect any downstream consumers as it is just the addition of a new field.

# How Has This Been Tested?

I built the changes and referenced them from a connector to verify that I can set the field and that the connector can return it in its JSON response.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [-] I have added tests that prove my fix is effective or that my feature works
