### PR TITLE
feat: add challenges to payout model

### DIFF
--- a/mdx-models/src/main/java/com/mx/path/model/mdx/model/payout/Payout.java
+++ b/mdx-models/src/main/java/com/mx/path/model/mdx/model/payout/Payout.java
@@ -2,12 +2,19 @@ package com.mx.path.model.mdx.model.payout;
 
 import java.time.LocalDate;
 
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
 import com.mx.path.model.mdx.model.MdxBase;
+import com.mx.path.model.mdx.model.MdxList;
+import com.mx.path.model.mdx.model.challenges.Challenge;
 
+@Data
+@EqualsAndHashCode(callSuper = true)
 public final class Payout extends MdxBase<Payout> {
-
   private String accountId;
   private Double amount;
+  private MdxList<Challenge> challenges;
   private String confirmationId;
   private LocalDate expiresOn;
   private Double fee;
@@ -29,188 +36,4 @@ public final class Payout extends MdxBase<Payout> {
   private String type;
   private String challengeQuestion;
   private String challengeAnswer;
-
-  public String getAccountId() {
-    return accountId;
-  }
-
-  public void setAccountId(String newAccountId) {
-    this.accountId = newAccountId;
-  }
-
-  public Double getAmount() {
-    return amount;
-  }
-
-  public void setAmount(Double newAmount) {
-    this.amount = newAmount;
-  }
-
-  public String getConfirmationId() {
-    return confirmationId;
-  }
-
-  public void setConfirmationId(String newConfirmationId) {
-    this.confirmationId = newConfirmationId;
-  }
-
-  public LocalDate getExpiresOn() {
-    return expiresOn;
-  }
-
-  public void setExpiresOn(LocalDate newExpiresOn) {
-    this.expiresOn = newExpiresOn;
-  }
-
-  public Double getFee() {
-    return fee;
-  }
-
-  public void setFee(Double newFee) {
-    this.fee = newFee;
-  }
-
-  public String getId() {
-    return id;
-  }
-
-  public void setId(String newId) {
-    this.id = newId;
-  }
-
-  public String getMemo() {
-    return memo;
-  }
-
-  public void setMemo(String newMemo) {
-    this.memo = newMemo;
-  }
-
-  public String getNameCheckWarningTitle() {
-    return nameCheckWarningTitle;
-  }
-
-  public void setNameCheckWarningTitle(String newNameCheckWarningTitle) {
-    this.nameCheckWarningTitle = newNameCheckWarningTitle;
-  }
-
-  public String getNameCheckWarningText() {
-    return nameCheckWarningText;
-  }
-
-  public void setNameCheckWarningText(String newNameCheckWarningText) {
-    this.nameCheckWarningText = newNameCheckWarningText;
-  }
-
-  public String getPayoutMethodId() {
-    return payoutMethodId;
-  }
-
-  public void setPayoutMethodId(String payoutMethodId) {
-    this.payoutMethodId = payoutMethodId;
-  }
-
-  public String getPayoutRequestId() {
-    return payoutRequestId;
-  }
-
-  public void setPayoutRequestId(String newPayoutrequestId) {
-    this.payoutRequestId = newPayoutrequestId;
-  }
-
-  public String getRecipientId() {
-    return recipientId;
-  }
-
-  public void setRecipientId(String recipientId) {
-    this.recipientId = recipientId;
-  }
-
-  public String getRecurringPayoutId() {
-    return recurringPayoutId;
-  }
-
-  public void setRecurringPayoutId(String newRecurringPayoutId) {
-    this.recurringPayoutId = newRecurringPayoutId;
-  }
-
-  public String getStatus() {
-    return status;
-  }
-
-  public void setStatus(String newStatus) {
-    this.status = newStatus;
-  }
-
-  public String getSenderName() {
-    return senderName;
-  }
-
-  public void setSenderName(String newSenderName) {
-    this.senderName = newSenderName;
-  }
-
-  public LocalDate getSendOn() {
-    return sendOn;
-  }
-
-  public void setSendOn(LocalDate newSentOnAt) {
-    this.sendOn = newSentOnAt;
-  }
-
-  public Long getSentAt() {
-    return sentAt;
-  }
-
-  public void setSentAt(Long newSentAt) {
-    this.sentAt = newSentAt;
-  }
-
-  public LocalDate getSentOn() {
-    return sentOn;
-  }
-
-  public void setSentOn(LocalDate newSentOn) {
-    this.sentOn = newSentOn;
-  }
-
-  public String getSpeedText() {
-    return speedText;
-  }
-
-  public void setSpeedText(String newSpeedText) {
-    this.speedText = newSpeedText;
-  }
-
-  public String getToken() {
-    return token;
-  }
-
-  public void setToken(String newToken) {
-    this.token = newToken;
-  }
-
-  public String getType() {
-    return type;
-  }
-
-  public void setType(String newType) {
-    this.type = newType;
-  }
-
-  public String getChallengeQuestion() {
-    return challengeQuestion;
-  }
-
-  public void setChallengeQuestion(String challengeQuestion) {
-    this.challengeQuestion = challengeQuestion;
-  }
-
-  public String getChallengeAnswer() {
-    return challengeAnswer;
-  }
-
-  public void setChallengeAnswer(String challengeAnswer) {
-    this.challengeAnswer = challengeAnswer;
-  }
 }

--- a/mdx-web/src/main/java/com/mx/path/model/mdx/web/controller/PayoutsController.java
+++ b/mdx-web/src/main/java/com/mx/path/model/mdx/web/controller/PayoutsController.java
@@ -29,7 +29,14 @@ public class PayoutsController extends BaseController {
   @RequestMapping(value = "/payouts", method = RequestMethod.POST, consumes = BaseController.MDX_MEDIA)
   public final ResponseEntity<Payout> createPayout(@RequestBody Payout payoutRequest) {
     AccessorResponse<Payout> response = gateway().payouts().create(payoutRequest);
-    return new ResponseEntity<>(response.getResult().wrapped(), createMultiMapForResponse(response.getHeaders()), HttpStatus.OK);
+
+    // Return 202 returning challenge questions
+    Payout result = response.getResult();
+    HttpStatus status = HttpStatus.OK;
+    if (result.getChallenges() != null && !result.getChallenges().isEmpty()) {
+      status = HttpStatus.ACCEPTED;
+    }
+    return new ResponseEntity<>(response.getResult().wrapped(), createMultiMapForResponse(response.getHeaders()), status);
   }
 
   @RequestMapping(value = "/payouts/{id}/cancel", method = RequestMethod.PUT)

--- a/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/PayoutsControllerTest.groovy
+++ b/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/PayoutsControllerTest.groovy
@@ -10,6 +10,7 @@ import com.mx.path.gateway.api.payout.PayoutMethodGateway
 import com.mx.path.gateway.api.payout.RecipientGateway
 import com.mx.path.model.mdx.model.MdxList
 import com.mx.path.model.mdx.model.account.Account
+import com.mx.path.model.mdx.model.challenges.Challenge
 import com.mx.path.model.mdx.model.payout.Payout
 import com.mx.path.model.mdx.model.payout.PayoutMethod
 import com.mx.path.model.mdx.model.payout.Recipient
@@ -72,6 +73,27 @@ class PayoutsControllerTest extends Specification implements WithMockery {
     response.getStatusCode() == HttpStatus.OK
     response.getBody().getWrapped()
     response.getBody() == payout
+  }
+
+  def "CreatePayout with challenges"() {
+    given:
+    BaseController.setGateway(gateway)
+
+    def payout = new Payout().tap {
+      setChallenges(new MdxList<Challenge>().tap {
+        add(new Challenge())
+      })
+    }
+
+    Mockito.doReturn(new AccessorResponse<Payout>().withResult(payout)).when(payoutGateway).create(payout)
+
+    when:
+    def response = subject.createPayout(payout)
+
+    then:
+    verify(payoutGateway).create(payout) || true
+    response.statusCode == HttpStatus.ACCEPTED
+    response.body == payout
   }
 
   def "CancelPayout interacts with gateway"() {


### PR DESCRIPTION
# Summary of Changes

Adds challenges to payout model and update model to use lombok getter/setters. And returns a 202 if challenges are present in the create payout response

Fixes # (issue)

## Public API Additions/Changes

Adds challenges to payouts https://developer.mx.com/drafts/mdx/payout/#payouts-create-a-payout

## Downstream Consumer Impact

This shouldn't have any impact since it's just adding new functionality.

# How Has This Been Tested?
I pulled in these changes locally and ran the e2e tests and they all passed. I also verified that if the response has challenges that a 202 is returned

```
POST http://localhost:3015/globalcu/users/U-00ujqk7rkv4L6FFWK1d7/payouts

HTTP/1.1 202 
Content-Type: application/vnd.mx.mdx.v6+json;charset=UTF-8
Transfer-Encoding: chunked
Date: Fri, 31 Jan 2025 21:47:47 GMT

{
  "payout": {
    "challenges": [
      {
        "id": "an-id",
        "user_id": "U-00ujqk7rkv4L6FFWK1d7"
      }
    ],
    "user_id": "U-00ujqk7rkv4L6FFWK1d7"
  }
}
```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
