### PR TITLE
feat: add card_manager_data to authorization model

### DIFF
--- a/mdx-models/src/main/java/com/mx/path/model/mdx/model/authorization/Authorization.java
+++ b/mdx-models/src/main/java/com/mx/path/model/mdx/model/authorization/Authorization.java
@@ -13,6 +13,7 @@ import com.mx.path.model.mdx.model.challenges.Challenge;
 @EqualsAndHashCode(callSuper = true)
 public class Authorization extends MdxBase<Authorization> {
   private String accountId;
+  private CardManagerData cardManagerData;
   private List<Challenge> challenges;
   private NameValuePair[] cookies;
   @SerializedName("cookies_url")

--- a/mdx-models/src/main/java/com/mx/path/model/mdx/model/authorization/CardDetail.java
+++ b/mdx-models/src/main/java/com/mx/path/model/mdx/model/authorization/CardDetail.java
@@ -1,0 +1,15 @@
+package com.mx.path.model.mdx.model.authorization;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+import com.mx.path.model.mdx.model.MdxBase;
+import com.mx.path.model.mdx.model.MdxNested;
+
+@MdxNested
+@Data
+@EqualsAndHashCode(callSuper = true)
+public class CardDetail extends MdxBase<CardDetail> {
+  private String id;
+  private String alias;
+}

--- a/mdx-models/src/main/java/com/mx/path/model/mdx/model/authorization/CardManagerData.java
+++ b/mdx-models/src/main/java/com/mx/path/model/mdx/model/authorization/CardManagerData.java
@@ -1,0 +1,17 @@
+package com.mx.path.model.mdx.model.authorization;
+
+import java.util.List;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+import com.mx.path.model.mdx.model.MdxBase;
+import com.mx.path.model.mdx.model.MdxNested;
+
+@MdxNested
+@Data
+@EqualsAndHashCode(callSuper = true)
+public class CardManagerData extends MdxBase<CardManagerData> {
+  private String authUserId;
+  private List<CardDetail> cardDetails;
+}


### PR DESCRIPTION
# Summary of Changes

Adds card_manager_data to Authorization model

## Public API Additions/Changes

Changes found here https://developer.mx.com/drafts/mdx/authorization/#authorizations

## Downstream Consumer Impact

No impact. Just adds new fields

# How Has This Been Tested?

I tested this locally and verified the fields we're getting created correctly

```
{
  "authorization": {
    "card_manager_data": {
      "auth_user_id": "authUserId",
      "card_details": [
        {
          "id": "CARD_ID_1",
          "alias": "CARD_ALIAS_1"
        },
        {
          "id": "CARD_ID_2",
          "alias": "CARD_ALIAS_2"
        }
      ]
    },
    "type": "CARD_MANAGER",
    "user_id": "U-00uhy5wx4hn4R0KLL1d7"
  }
}
```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
