### PR TITLE
feat: add RDC eligibility fields to Profile model

### DIFF
--- a/mdx-models/src/main/java/com/mx/path/model/mdx/model/profile/Profile.java
+++ b/mdx-models/src/main/java/com/mx/path/model/mdx/model/profile/Profile.java
@@ -2,71 +2,33 @@ package com.mx.path.model.mdx.model.profile;
 
 import java.time.LocalDate;
 
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
 import com.google.gson.annotations.SerializedName;
+import com.mx.path.core.common.model.Internal;
 import com.mx.path.model.mdx.model.MdxBase;
 
+@Data
+@EqualsAndHashCode(callSuper = true)
 public final class Profile extends MdxBase<Profile> {
   @SerializedName("birth_date_on")
   private LocalDate birthDate;
-  @SerializedName("first_name")
   private String firstName;
   private Gender gender;
-  @SerializedName("last_name")
   private String lastName;
-  @SerializedName("middle_name")
   private String middleName;
   private String ssn;
 
-  public Profile() {
-  }
-
-  public LocalDate getBirthDate() {
-    return birthDate;
-  }
-
-  public void setBirthDate(LocalDate birthDate) {
-    this.birthDate = birthDate;
-  }
-
-  public String getFirstName() {
-    return firstName;
-  }
-
-  public void setFirstName(String firstName) {
-    this.firstName = firstName;
-  }
-
-  public Gender getGender() {
-    return gender;
-  }
-
-  public void setGender(Gender gender) {
-    this.gender = gender;
-  }
-
-  public String getLastName() {
-    return lastName;
-  }
-
-  public void setLastName(String lastName) {
-    this.lastName = lastName;
-  }
-
-  public String getMiddleName() {
-    return middleName;
-  }
-
-  public void setMiddleName(String middleName) {
-    this.middleName = middleName;
-  }
-
-  public String getSsn() {
-    return ssn;
-  }
-
-  public void setSsn(String ssn) {
-    this.ssn = ssn;
-  }
+  // --------------------------------------------------------
+  // Internal Fields
+  //  ** These fields will not render in web responses.
+  //  ** They are only for internal communication.
+  // --------------------------------------------------------
+  @Internal
+  private boolean remoteDepositEligible;
+  @Internal
+  private boolean remoteDepositEnrolled;
 
   // enum definition
 


### PR DESCRIPTION
# Summary of Changes

Adding RDC internal eligibility fields to Profile model so that we can use gateway instead of NATS. These fields are internal so they won't get generated on the response

Fixes # (issue) https://mxcom.atlassian.net/browse/GCU-830

## Public API Additions/Changes

No public API changes, just adds internal fields

## Downstream Consumer Impact

None

# How Has This Been Tested?

Pulled these changes into a service and verified fields got generated still

```
GET http://localhost:3009/globalcu/users/U-00u3la36x0bbNvPud1d7/profile

HTTP/1.1 200 
Content-Type: application/vnd.mx.mdx.v6+json;charset=UTF-8
Transfer-Encoding: chunked
Date: Thu, 13 Mar 2025 21:41:27 GMT

{
  "profile": {
    "birth_date_on": "2025-03-13",
    "first_name": "First Name",
    "gender": "FEMALE",
    "last_name": "Last Name",
    "middle_name": "Middle Name",
    "ssn": "11111111",
    "user_id": "U-00u3la36x0bbNvPud1d7"
  }
}
```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
