### PR TITLE
feat: add billpay eligibility fields to Profile model

### DIFF
--- a/mdx-models/src/main/java/com/mx/path/model/mdx/model/profile/Profile.java
+++ b/mdx-models/src/main/java/com/mx/path/model/mdx/model/profile/Profile.java
@@ -25,6 +25,11 @@ public final class Profile extends MdxBase<Profile> {
   //  ** These fields will not render in web responses.
   //  ** They are only for internal communication.
   // --------------------------------------------------------
+
+  @Internal
+  private boolean billPayEligible;
+  @Internal
+  private boolean billPayEnrolled;
   @Internal
   private boolean remoteDepositEligible;
   @Internal


### PR DESCRIPTION
# Summary of Changes

Adding billpay internal eligibility fields to Profile model so that we can use gateway instead of NATS. These fields are internal so they won't get generated on the response

Fixes # (issue) https://mxcom.atlassian.net/browse/GCU-873

## Public API Additions/Changes

No public API changes, just adds internal fields

## Downstream Consumer Impact

None

# How Has This Been Tested?

Pulled these changes into a service and verified fields got generated still

```
GET http://localhost:3009/globalcu/users/U-00u3la36x0bbNvPud1d7/profile

HTTP/1.1 200 
Content-Type: application/vnd.mx.mdx.v6+json;charset=UTF-8
Transfer-Encoding: chunked
Date: Thu, 13 Mar 2025 21:41:27 GMT

{
  "profile": {
    "birth_date_on": "2025-03-13",
    "first_name": "First Name",
    "gender": "FEMALE",
    "last_name": "Last Name",
    "middle_name": "Middle Name",
    "ssn": "11111111",
    "user_id": "U-00u3la36x0bbNvPud1d7"
  }
}
```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
