### PR TITLE
fix: add VANTAGE_SCORE as one of the score versions in Path Models

### DIFF
--- a/mdx-models/src/main/java/com/mx/path/model/mdx/model/credit_report/CreditReport.java
+++ b/mdx-models/src/main/java/com/mx/path/model/mdx/model/credit_report/CreditReport.java
@@ -75,7 +75,7 @@ public final class CreditReport extends MdxBase<CreditReport> {
   }
 
   public enum ScoreVersions {
-    FICO_SCORE_8("Fico Score 8"), FICO_SCORE_9("Fico Score 9");
+    FICO_SCORE_8("Fico Score 8"), FICO_SCORE_9("Fico Score 9"), VANTAGE_SCORE("Vantage Score");
 
     private final String description;
 


### PR DESCRIPTION
# Summary of Changes

For CPB Credit Score integration with Savvy Money, adding VANTAGE_SCORE as one of the score versions in Path Models.

Fixes # https://mxcom.atlassian.net/browse/IM-326

## Public API Additions/Changes

Here is the link to update spec : https://developer.mx.com/drafts/mdx/credit_report/index.html#credit-reports-credit-report-fields

## Downstream Consumer Impact

This is a new requirement and won't impact downstream consumers.

# How Has This Been Tested?

I tested this locally by publishing a version of Models. 

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
