### PR TITLE
fix: updating score version

### DIFF
--- a/mdx-models/src/main/java/com/mx/path/model/mdx/model/credit_report/CreditReport.java
+++ b/mdx-models/src/main/java/com/mx/path/model/mdx/model/credit_report/CreditReport.java
@@ -75,7 +75,7 @@ public final class CreditReport extends MdxBase<CreditReport> {
   }
 
   public enum ScoreVersions {
-    FICO_SCORE_8("Fico Score 8"), FICO_SCORE_9("Fico Score 9"), VANTAGE_SCORE("Vantage Score");
+    FICO_SCORE_8("Fico Score 8"), FICO_SCORE_9("Fico Score 9"), VANTAGE_SCORE_3("Vantage Score 3");
 
     private final String description;
 


### PR DESCRIPTION
# Summary of Changes

We have updated spec to use VANTAGE_SCORE_3 as different vantage score has different ranges. Vantage score 2.0 is ranges 501-990 scale , vantage score 3.0 is ranges 300 to 850. There is also a vantage score 4.0 but savvymoney doesn’t use it yet!

https://developer.mx.com/drafts/mdx/credit_report/index.html#credit-reports-credit-report-fields

Fixes # (issue)
https://mxcom.atlassian.net/browse/IM-326

## Public API Additions/Changes

https://developer.mx.com/drafts/mdx/credit_report/index.html#credit-reports-credit-report-fields

## Downstream Consumer Impact

This is a new feature, no impact on existing clients

# How Has This Been Tested?

Verified locally by publishing this version of model

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
