### PR TITLE
feat: add amountOptionId to transfer and recurringTransfer

### DIFF
--- a/mdx-models/src/main/java/com/mx/path/model/mdx/model/transfer/RecurringTransfer.java
+++ b/mdx-models/src/main/java/com/mx/path/model/mdx/model/transfer/RecurringTransfer.java
@@ -18,6 +18,7 @@ public final class RecurringTransfer extends MdxBase<RecurringTransfer> {
   private List<Challenge> challenges;
 
   private Double amount;
+  private String amountOptionId;
   private String confirmationId;
   private Double endAfterAmount;
   private Integer endAfterCount;

--- a/mdx-models/src/main/java/com/mx/path/model/mdx/model/transfer/Transfer.java
+++ b/mdx-models/src/main/java/com/mx/path/model/mdx/model/transfer/Transfer.java
@@ -19,6 +19,7 @@ public final class Transfer extends MdxBase<Transfer> {
   private List<Challenge> challenges;
 
   private Double amount;
+  private String amountOptionId;
   private String confirmationId;
   private Long createdAt;
   private LocalDate createdOn;


### PR DESCRIPTION
# Summary of Changes

Adds `amount_option_id` to `transfer` and `recurring_transfer`. It is already detailed in the MDX Spec as well as supported by Mobile and Synchronicity.

Fixes # [5092](https://mxcom.atlassian.net/browse/MC-5092)

## Public API Additions/Changes

Adds `amount_option_id` to both `transfer` and `recurring_transfer`

## Downstream Consumer Impact

This will be used to fix a bug where user sent `amount_option_id` was not being honored

# How Has This Been Tested?

Simple field addition, testing will be done in accessor

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
