### PR TITLE
fix: disable request logging filter

### DIFF
--- a/mdx-web/src/main/java/com/mx/path/model/mdx/web/filter/PathRequestLoggingFilter.java
+++ b/mdx-web/src/main/java/com/mx/path/model/mdx/web/filter/PathRequestLoggingFilter.java
@@ -25,8 +25,6 @@ import com.mx.path.model.mdx.model.MdxLogMasker;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
-import org.springframework.core.annotation.Order;
-import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 import org.springframework.web.util.ContentCachingRequestWrapper;
 import org.springframework.web.util.ContentCachingResponseWrapper;
@@ -37,8 +35,9 @@ import org.springframework.web.util.ContentCachingResponseWrapper;
  * This filter logs incoming requests.
  * These values are inserted into the MDC.
  */
-@Component
-@Order(FilterOrderSequence.REQUEST_LOGGING_FILTER)
+// TODO Needs more testing before enabling. This is causing opensearch issues
+//@Component
+//@Order(FilterOrderSequence.REQUEST_LOGGING_FILTER)
 public class PathRequestLoggingFilter extends OncePerRequestFilter {
 
   // Statics


### PR DESCRIPTION
# Summary of Changes

Disabling request logging filter for now. It's causing some schema collision in opensearch

Fixes # (issue)

## Public API Additions/Changes

None

## Downstream Consumer Impact

Just removes request logging filter which is new logging

# How Has This Been Tested?

I published this locally and pulled it into a connector. Verified it ran ok. Also did breakpoints to verify this filter wasn't being used

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
