### PR TITLE
fix: ignore k8s health logs in path request logging filter

### DIFF
--- a/mdx-web/src/main/java/com/mx/path/model/mdx/web/filter/PathRequestLoggingFilter.java
+++ b/mdx-web/src/main/java/com/mx/path/model/mdx/web/filter/PathRequestLoggingFilter.java
@@ -74,7 +74,7 @@ public class PathRequestLoggingFilter extends OncePerRequestFilter {
       // Pass request to next filter with wrappers to support logging request and response bodies
       filterChain.doFilter(requestWrapper, responseWrapper);
     } finally {
-      if (!request.getRequestURI().contains("/status")) {
+      if (!request.getRequestURI().contains("/health") && !request.getRequestURI().contains("/status")) {
         try {
           this.logRequest(requestWrapper, responseWrapper, requestStartTimeMillis);
         } catch (Exception ex) {

--- a/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/filter/PathRequestLoggingFilterTest.groovy
+++ b/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/filter/PathRequestLoggingFilterTest.groovy
@@ -19,6 +19,7 @@ import org.springframework.web.util.ContentCachingRequestWrapper
 import org.springframework.web.util.ContentCachingResponseWrapper
 
 import spock.lang.Specification
+import spock.lang.Unroll
 
 class PathRequestLoggingFilterTest extends Specification {
   HttpServletRequest request
@@ -205,7 +206,8 @@ class PathRequestLoggingFilterTest extends Specification {
     MDC.get("response_headers") == "Content-Length: 50\nmx-session-key: **MASKED**\nContent-Type: application/vnd.mx.mdx.v6+json\n"
   }
 
-  def "skips logging when requestURI contains status"() {
+  @Unroll
+  def "skips logging when requestURI contains #request_uri"() {
     given:
     when(request.getRequestURI()).thenReturn("path-connector-<client-id>/status")
 
@@ -214,6 +216,11 @@ class PathRequestLoggingFilterTest extends Specification {
 
     then:
     verify(subject, never()).logRequest(any(ContentCachingRequestWrapper), any(ContentCachingResponseWrapper), anyLong()) || true
+
+    where:
+    request_uri                               || _
+    "http://10.66.90.77:3000/actuator/health" || _
+    "path-connector-<client-id>/status"       || _
   }
 
   private class PathRequestLoggingFilterWithNoMDCClearing extends PathRequestLoggingFilter {


### PR DESCRIPTION
# Summary of Changes

Drop k8s health logs in PathRequestLoggingFilter

## Public API Additions/Changes

None

## Downstream Consumer Impact

None

# How Has This Been Tested?

Tested locally

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
