### PR TITLE
feat: add CardSwitchData to Authorization

### DIFF
--- a/mdx-models/src/main/java/com/mx/path/model/mdx/model/authorization/Authorization.java
+++ b/mdx-models/src/main/java/com/mx/path/model/mdx/model/authorization/Authorization.java
@@ -14,6 +14,7 @@ import com.mx.path.model.mdx.model.challenges.Challenge;
 public class Authorization extends MdxBase<Authorization> {
   private String accountId;
   private CardManagerData cardManagerData;
+  private CardSwitchData cardSwitchData;
   private List<Challenge> challenges;
   private ChatData chatData;
   private NameValuePair[] cookies;

--- a/mdx-models/src/main/java/com/mx/path/model/mdx/model/authorization/CardSwitchData.java
+++ b/mdx-models/src/main/java/com/mx/path/model/mdx/model/authorization/CardSwitchData.java
@@ -1,0 +1,14 @@
+package com.mx.path.model.mdx.model.authorization;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+import com.mx.path.model.mdx.model.MdxBase;
+import com.mx.path.model.mdx.model.MdxNested;
+
+@MdxNested
+@Data
+@EqualsAndHashCode(callSuper = true)
+public class CardSwitchData extends MdxBase<CardSwitchData> {
+  private String identifier;
+}


### PR DESCRIPTION
## Summary

Add a new MDX model class `CardSwitchData` (single `identifier` field) and expose it on the `Authorization` model. Mirrors the pattern of `CardManagerData`.

This is the Java counterpart of the `card_switch_data: { identifier }` field added to the Authorization MDX spec in MC-11025 (Gutenberg MR !925). Downstream Path connectors (sub-tasks of MC-11026) will consume this to thread the MX `user_guid` to Atomic.

Jira: [MC-11647](https://mxcom.atlassian.net/browse/MC-11647)
Parent: [MC-11026](https://mxcom.atlassian.net/browse/MC-11026)

## Test plan

- `./gradlew :mdx-models:build` passes locally
- No unit test added — consistent with the rest of the `model.authorization` package (Lombok-generated boilerplate, covered transitively by downstream consumer tests)

[MC-11647]: https://mxcom.atlassian.net/browse/MC-11647?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MC-11026]: https://mxcom.atlassian.net/browse/MC-11026?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ