### PR TITLE
fix(mdx-web): restore byte array message converter

### DIFF
--- a/mdx-web/src/main/java/com/mx/path/model/mdx/web/MdxOnDemandSerializationWebMvcConfigurer.java
+++ b/mdx-web/src/main/java/com/mx/path/model/mdx/web/MdxOnDemandSerializationWebMvcConfigurer.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.mx.path.model.mdx.model.Resources;
 
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.converter.ByteArrayHttpMessageConverter;
 import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.http.converter.StringHttpMessageConverter;
 import org.springframework.http.converter.json.GsonHttpMessageConverter;
@@ -25,6 +26,7 @@ public class MdxOnDemandSerializationWebMvcConfigurer implements WebMvcConfigure
     CONVERT_CLASSES = new ArrayList<>();
     CONVERT_CLASSES.add(GsonHttpMessageConverter.class);
     CONVERT_CLASSES.add(StringHttpMessageConverter.class);
+    CONVERT_CLASSES.add(ByteArrayHttpMessageConverter.class);
   }
 
   @Override

--- a/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/MdxOnDemandSerializationWebMvcConfigurerTest.groovy
+++ b/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/MdxOnDemandSerializationWebMvcConfigurerTest.groovy
@@ -1,0 +1,60 @@
+package com.mx.path.model.mdx.web
+
+import com.fasterxml.jackson.databind.module.SimpleModule
+
+import org.springframework.http.converter.ByteArrayHttpMessageConverter
+import org.springframework.http.converter.FormHttpMessageConverter
+import org.springframework.http.converter.ResourceHttpMessageConverter
+import org.springframework.http.converter.StringHttpMessageConverter
+import org.springframework.http.converter.json.GsonHttpMessageConverter
+import org.springframework.http.converter.xml.MappingJackson2XmlHttpMessageConverter
+
+import spock.lang.Specification
+
+class MdxOnDemandSerializationWebMvcConfigurerTest extends Specification {
+
+  MdxOnDemandSerializationWebMvcConfigurer subject
+
+  def setup() {
+    subject = new MdxOnDemandSerializationWebMvcConfigurer()
+  }
+
+  def "filters non-whitelisted message converters and appends the custom XML converter"() {
+    given:
+    def gsonConverter = new GsonHttpMessageConverter()
+    def stringConverter = new StringHttpMessageConverter()
+    def byteArrayConverter = new ByteArrayHttpMessageConverter()
+    def unwantedResourceConverter = new ResourceHttpMessageConverter()
+    def unwantedFormConverter = new FormHttpMessageConverter()
+
+    def converters = [
+      unwantedResourceConverter,
+      gsonConverter,
+      unwantedFormConverter,
+      stringConverter,
+      byteArrayConverter
+    ]
+
+    when:
+    subject.configureMessageConverters(converters)
+
+    then:
+    verifyAll(converters) {
+      it.size() == 4
+      it.contains(gsonConverter)
+      it.contains(stringConverter)
+      it.contains(byteArrayConverter)
+      !it.contains(unwantedResourceConverter)
+      !it.contains(unwantedFormConverter)
+      it.last() instanceof MappingJackson2XmlHttpMessageConverter
+    }
+  }
+
+  def "payloadModule returns a correctly instantiated SimpleModule"() {
+    when:
+    def module = subject.payloadModule()
+
+    then:
+    module instanceof SimpleModule
+  }
+}


### PR DESCRIPTION
# Summary of Changes

Adds back the default Spring `ByteArrayHttpMessageConverter`. This resolves an issue where the `/actuator/prometheus` endpoint was returning a 500 status response because the prometheus endpoint returns a byte array instead of a string.

Fixes # [GCU-1340](https://mxcom.atlassian.net/browse/GCU-1340)

## Public API Additions/Changes

N/A

## Downstream Consumer Impact

Spring Boot services will be able to query prometheus metrics without getting an error, as long as the endpoint is enabled in the Spring configuration (`application.yml` or `application.properties`).

# How Has This Been Tested?

I pulled a snapshot version of these changes into `path-connector-globalcu` and verified the `/actuator/prometheus` endpoint is working as expected.

<details>
<summary>Prometheus Response</summary>

```
2026-05-18 12:39:42,066 INFO  [http-nio-3009-exec-2] c.m.p.m.m.w.f.PathRequestLoggingFilter:

                
= Request

GET http://localhost:3009/actuator/prometheus

host: localhost:3009
user-agent: curl/8.7.1
accept: */*

= Response

200
Content-Length: 18618
Content-Type: text/plain;version=0.0.4;charset=utf-8
# HELP application_ready_time_seconds Time taken for the application to be ready to service requests
# TYPE application_ready_time_seconds gauge
application_ready_time_seconds{application="path-connector-globalcu",main_application_class="globalcu.GlobalCUApplication"} 5.797
# HELP application_started_time_seconds Time taken to start the application
# TYPE application_started_time_seconds gauge
application_started_time_seconds{application="path-connector-globalcu",main_application_class="globalcu.GlobalCUApplication"} 5.781
# HELP disk_free_bytes Usable space for path
# TYPE disk_free_bytes gauge
disk_free_bytes{application="path-connector-globalcu",path="/Users/steven.leighton/dev/path-connector-globalcu/."} 1.25008797696E11
# HELP disk_total_bytes Total space for path
# TYPE disk_total_bytes gauge
disk_total_bytes{application="path-connector-globalcu",path="/Users/steven.leighton/dev/path-connector-globalcu/."} 4.94384795648E11
# HELP executor_active_threads The approximate number of threads that are actively executing tasks
# TYPE executor_active_threads gauge
executor_active_threads{application="path-connector-globalcu",name="applicationTaskExecutor"} 0.0
# HELP executor_completed_tasks_total The approximate total number of tasks that have completed execution
# TYPE executor_completed_tasks_total counter
executor_completed_tasks_total{application="path-connector-globalcu",name="applicationTaskExecutor"} 0.0
# HELP executor_pool_core_threads The core number of threads for the pool
# TYPE executor_pool_core_threads gauge
executor_pool_core_threads{application="path-connector-globalcu",name="applicationTaskExecutor"} 8.0
# HELP executor_pool_max_threads The maximum allowed number of threads in the pool
# TYPE executor_pool_max_threads gauge
executor_pool_max_threads{application="path-connector-globalcu",name="applicationTaskExecutor"} 2.147483647E9
# HELP executor_pool_size_threads The current number of threads in the pool
# TYPE executor_pool_size_threads gauge
executor_pool_size_threads{application="path-connector-globalcu",name="applicationTaskExecutor"} 0.0
# HELP executor_queue_remaining_tasks The number of additional elements that this queue can ideally accept without blocking
# TYPE executor_queue_remaining_tasks gauge
executor_queue_remaining_tasks{application="path-connector-globalcu",name="applicationTaskExecutor"} 2.147483647E9
# HELP executor_queued_tasks The approximate number of tasks that are queued for execution
# TYPE executor_queued_tasks gauge
executor_queued_tasks{application="path-connector-globalcu",name="applicationTaskExecutor"} 0.0
# HELP http_server_requests_active_seconds  
# TYPE http_server_requests_active_seconds summary
http_server_requests_active_seconds_count{application="path-connector-globalcu",exception="none",method="GET",outcome="SUCCESS",status="200",uri="UNKNOWN"} 1
http_server_requests_active_seconds_sum{application="path-connector-globalcu",exception="none",method="GET",outcome="SUCCESS",status="200",uri="UNKNOWN"} 0.117531166
# HELP http_server_requests_active_seconds_max  
# TYPE http_server_requests_active_seconds_max gauge
http_server_requests_active_seconds_max{application="path-connector-globalcu",exception="none",method="GET",outcome="SUCCESS",status="200",uri="UNKNOWN"} 0.1176065
# HELP jvm_info JVM version info
# TYPE jvm_info gauge
jvm_info{application="path-connector-globalcu",runtime="OpenJDK Runtime Environment",vendor="Eclipse Adoptium",version="21.0.10+7-LTS"} 1
# HELP jvm_buffer_count_buffers An estimate of the number of buffers in the pool
# TYPE jvm_buffer_count_buffers gauge
jvm_buffer_count_buffers{application="path-connector-globalcu",id="direct"} 4.0
jvm_buffer_count_buffers{application="path-connector-globalcu",id="mapped"} 0.0
jvm_buffer_count_buffers{application="path-connector-globalcu",id="mapped - 'non-volatile memory'"} 0.0
# HELP jvm_buffer_memory_used_bytes An estimate of the memory that the Java virtual machine is using for this buffer pool
# TYPE jvm_buffer_memory_used_bytes gauge
jvm_buffer_memory_used_bytes{application="path-connector-globalcu",id="direct"} 57343.0
jvm_buffer_memory_used_bytes{application="path-connector-globalcu",id="mapped"} 0.0
jvm_buffer_memory_used_bytes{application="path-connector-globalcu",id="mapped - 'non-volatile memory'"} 0.0
# HELP jvm_buffer_total_capacity_bytes An estimate of the total capacity of the buffers in this pool
# TYPE jvm_buffer_total_capacity_bytes gauge
jvm_buffer_total_capacity_bytes{application="path-connector-globalcu",id="direct"} 57343.0
jvm_buffer_total_capacity_bytes{application="path-connector-globalcu",id="mapped"} 0.0
jvm_buffer_total_capacity_bytes{application="path-connector-globalcu",id="mapped - 'non-volatile memory'"} 0.0
# HELP jvm_classes_loaded_classes The number of classes that are currently loaded in the Java virtual machine
# TYPE jvm_classes_loaded_classes gauge
jvm_classes_loaded_classes{application="path-connector-globalcu"} 12518.0
# HELP jvm_classes_unloaded_classes_total The number of classes unloaded in the Java virtual machine
# TYPE jvm_classes_unloaded_classes_total counter
jvm_classes_unloaded_classes_total{application="path-connector-globalcu"} 0.0
# HELP jvm_compilation_time_ms_total The approximate accumulated elapsed time spent in compilation
# TYPE jvm_compilation_time_ms_total counter
jvm_compilation_time_ms_total{application="path-connector-globalcu",compiler="HotSpot 64-Bit Tiered Compilers"} 1826.0
# HELP jvm_gc_concurrent_phase_time_seconds Time spent in concurrent phase
# TYPE jvm_gc_concurrent_phase_time_seconds summary
jvm_gc_concurrent_phase_time_seconds_count{action="end of concurrent GC pause",application="path-connector-globalcu",cause="No GC",gc="G1 Concurrent GC"} 2
jvm_gc_concurrent_phase_time_seconds_sum{action="end of concurrent GC pause",application="path-connector-globalcu",cause="No GC",gc="G1 Concurrent GC"} 0.028
# HELP jvm_gc_concurrent_phase_time_seconds_max Time spent in concurrent phase
# TYPE jvm_gc_concurrent_phase_time_seconds_max gauge
jvm_gc_concurrent_phase_time_seconds_max{action="end of concurrent GC pause",application="path-connector-globalcu",cause="No GC",gc="G1 Concurrent GC"} 0.0
# HELP jvm_gc_live_data_size_bytes Size of long-lived heap memory pool after reclamation
# TYPE jvm_gc_live_data_size_bytes gauge
jvm_gc_live_data_size_bytes{application="path-connector-globalcu"} 0.0
# HELP jvm_gc_max_data_size_bytes Max size of long-lived heap memory pool
# TYPE jvm_gc_max_data_size_bytes gauge
jvm_gc_max_data_size_bytes{application="path-connector-globalcu"} 8.589934592E9
# HELP jvm_gc_memory_allocated_bytes_total Incremented for an increase in the size of the (young) heap memory pool after one GC to before the next
# TYPE jvm_gc_memory_allocated_bytes_total counter
jvm_gc_memory_allocated_bytes_total{application="path-connector-globalcu"} 4.194304E7
# HELP jvm_gc_memory_promoted_bytes_total Count of positive increases in the size of the old generation memory pool before GC to after GC
# TYPE jvm_gc_memory_promoted_bytes_total counter
jvm_gc_memory_promoted_bytes_total{application="path-connector-globalcu"} 3539360.0
# HELP jvm_gc_overhead An approximation of the percent of CPU time used by GC activities over the last lookback period or since monitoring began, whichever is shorter, in the range [0..1]
# TYPE jvm_gc_overhead gauge
jvm_gc_overhead{application="path-connector-globalcu"} 0.0
# HELP jvm_gc_pause_seconds Time spent in GC pause
# TYPE jvm_gc_pause_seconds summary
jvm_gc_pause_seconds_count{action="end of minor GC",application="path-connector-globalcu",cause="Metadata GC Threshold",gc="G1 Young Generation"} 1
jvm_gc_pause_seconds_sum{action="end of minor GC",application="path-connector-globalcu",cause="Metadata GC Threshold",gc="G1 Young Generation"} 0.006
# HELP jvm_gc_pause_seconds_max Time spent in GC pause
# TYPE jvm_gc_pause_seconds_max gauge
jvm_gc_pause_seconds_max{action="end of minor GC",application="path-connector-globalcu",cause="Metadata GC Threshold",gc="G1 Young Generation"} 0.0
# HELP jvm_memory_committed_bytes The amount of memory in bytes that is committed for the Java virtual machine to use
# TYPE jvm_memory_committed_bytes gauge
jvm_memory_committed_bytes{application="path-connector-globalcu",area="heap",id="G1 Eden Space"} 9.6468992E7
jvm_memory_committed_bytes{application="path-connector-globalcu",area="heap",id="G1 Old Gen"} 5.8720256E7
jvm_memory_committed_bytes{application="path-connector-globalcu",area="heap",id="G1 Survivor Space"} 1.2582912E7
jvm_memory_committed_bytes{application="path-connector-globalcu",area="nonheap",id="CodeCache"} 1.3369344E7
jvm_memory_committed_bytes{application="path-connector-globalcu",area="nonheap",id="Compressed Class Space"} 8912896.0
jvm_memory_committed_bytes{application="path-connector-globalcu",area="nonheap",id="Metaspace"} 6.4684032E7
# HELP jvm_memory_max_bytes The maximum amount of memory in bytes that can be used for memory management
# TYPE jvm_memory_max_bytes gauge
jvm_memory_max_bytes{application="path-connector-globalcu",area="heap",id="G1 Eden Space"} -1.0
jvm_memory_max_bytes{application="path-connector-globalcu",area="heap",id="G1 Old Gen"} 8.589934592E9
jvm_memory_max_bytes{application="path-connector-globalcu",area="heap",id="G1 Survivor Space"} -1.0
jvm_memory_max_bytes{application="path-connector-globalcu",area="nonheap",id="CodeCache"} 5.0331648E7
jvm_memory_max_bytes{application="path-connector-globalcu",area="nonheap",id="Compressed Class Space"} 1.073741824E9
jvm_memory_max_bytes{application="path-connector-globalcu",area="nonheap",id="Metaspace"} -1.0
# HELP jvm_memory_usage_after_gc The percentage of long-lived heap pool used after the last GC event, in the range [0..1]
# TYPE jvm_memory_usage_after_gc gauge
jvm_memory_usage_after_gc{application="path-connector-globalcu",area="heap",pool="long-lived"} 0.004201272502541542
# HELP jvm_memory_used_bytes The amount of used memory
# TYPE jvm_memory_used_bytes gauge
jvm_memory_used_bytes{application="path-connector-globalcu",area="heap",id="G1 Eden Space"} 2.097152E7
jvm_memory_used_bytes{application="path-connector-globalcu",area="heap",id="G1 Old Gen"} 3.6088656E7
jvm_memory_used_bytes{application="path-connector-globalcu",area="heap",id="G1 Survivor Space"} 8601784.0
jvm_memory_used_bytes{application="path-connector-globalcu",area="nonheap",id="CodeCache"} 1.3324672E7
jvm_memory_used_bytes{application="path-connector-globalcu",area="nonheap",id="Compressed Class Space"} 8493240.0
jvm_memory_used_bytes{application="path-connector-globalcu",area="nonheap",id="Metaspace"} 6.3751136E7
# HELP jvm_threads_daemon_threads The current number of live daemon threads
# TYPE jvm_threads_daemon_threads gauge
jvm_threads_daemon_threads{application="path-connector-globalcu"} 23.0
# HELP jvm_threads_live_threads The current number of live threads including both daemon and non-daemon threads
# TYPE jvm_threads_live_threads gauge
jvm_threads_live_threads{application="path-connector-globalcu"} 27.0
# HELP jvm_threads_peak_threads The peak live thread count since the Java virtual machine started or peak was reset
# TYPE jvm_threads_peak_threads gauge
jvm_threads_peak_threads{application="path-connector-globalcu"} 34.0
# HELP jvm_threads_started_threads_total The total number of application threads started in the JVM
# TYPE jvm_threads_started_threads_total counter
jvm_threads_started_threads_total{application="path-connector-globalcu"} 46.0
# HELP jvm_threads_states_threads The current number of threads
# TYPE jvm_threads_states_threads gauge
jvm_threads_states_threads{application="path-connector-globalcu",state="blocked"} 0.0
jvm_threads_states_threads{application="path-connector-globalcu",state="new"} 0.0
jvm_threads_states_threads{application="path-connector-globalcu",state="runnable"} 11.0
jvm_threads_states_threads{application="path-connector-globalcu",state="terminated"} 0.0
jvm_threads_states_threads{application="path-connector-globalcu",state="timed-waiting"} 5.0
jvm_threads_states_threads{application="path-connector-globalcu",state="waiting"} 11.0
# HELP logback_events_total Number of log events that were enabled by the effective log level
# TYPE logback_events_total counter
logback_events_total{application="path-connector-globalcu",level="debug"} 0.0
logback_events_total{application="path-connector-globalcu",level="error"} 0.0
logback_events_total{application="path-connector-globalcu",level="info"} 6.0
logback_events_total{application="path-connector-globalcu",level="trace"} 0.0
logback_events_total{application="path-connector-globalcu",level="warn"} 0.0
# HELP process_cpu_time_ns_total The "cpu time" used by the Java Virtual Machine process
# TYPE process_cpu_time_ns_total counter
process_cpu_time_ns_total{application="path-connector-globalcu"} 1.4254507E10
# HELP process_cpu_usage The "recent cpu usage" for the Java Virtual Machine process
# TYPE process_cpu_usage gauge
process_cpu_usage{application="path-connector-globalcu"} 0.0
# HELP process_files_max_files The maximum file descriptor count
# TYPE process_files_max_files gauge
process_files_max_files{application="path-connector-globalcu"} 1048576.0
# HELP process_files_open_files The open file descriptor count
# TYPE process_files_open_files gauge
process_files_open_files{application="path-connector-globalcu"} 198.0
# HELP process_start_time_seconds Start time of the process since unix epoch.
# TYPE process_start_time_seconds gauge
process_start_time_seconds{application="path-connector-globalcu"} 1.779127876899E9
# HELP process_uptime_seconds The uptime of the Java virtual machine
# TYPE process_uptime_seconds gauge
process_uptime_seconds{application="path-connector-globalcu"} 1705.149
# HELP system_cpu_count The number of processors available to the Java virtual machine
# TYPE system_cpu_count gauge
system_cpu_count{application="path-connector-globalcu"} 8.0
# HELP system_cpu_usage The "recent cpu usage" of the system the application is running in
# TYPE system_cpu_usage gauge
system_cpu_usage{application="path-connector-globalcu"} 0.0
# HELP system_load_average_1m The sum of the number of runnable entities queued to available processors and the number of runnable entities running on the available processors averaged over a period of time
# TYPE system_load_average_1m gauge
system_load_average_1m{application="path-connector-globalcu"} 25.228515625
# HELP tomcat_cache_access_total  
# TYPE tomcat_cache_access_total counter
tomcat_cache_access_total{application="path-connector-globalcu"} 0.0
# HELP tomcat_cache_hit_total  
# TYPE tomcat_cache_hit_total counter
tomcat_cache_hit_total{application="path-connector-globalcu"} 0.0
# HELP tomcat_connections_config_max_connections  
# TYPE tomcat_connections_config_max_connections gauge
tomcat_connections_config_max_connections{application="path-connector-globalcu",name="http-nio-3009"} 8192.0
# HELP tomcat_connections_current_connections  
# TYPE tomcat_connections_current_connections gauge
tomcat_connections_current_connections{application="path-connector-globalcu",name="http-nio-3009"} 2.0
# HELP tomcat_connections_keepalive_current_connections  
# TYPE tomcat_connections_keepalive_current_connections gauge
tomcat_connections_keepalive_current_connections{application="path-connector-globalcu",name="http-nio-3009"} 1.0
# HELP tomcat_global_error_total  
# TYPE tomcat_global_error_total counter
tomcat_global_error_total{application="path-connector-globalcu",name="http-nio-3009"} 0.0
# HELP tomcat_global_received_bytes_total  
# TYPE tomcat_global_received_bytes_total counter
tomcat_global_received_bytes_total{application="path-connector-globalcu",name="http-nio-3009"} 0.0
# HELP tomcat_global_request_max_seconds  
# TYPE tomcat_global_request_max_seconds gauge
tomcat_global_request_max_seconds{application="path-connector-globalcu",name="http-nio-3009"} 0.0
# HELP tomcat_global_request_seconds  
# TYPE tomcat_global_request_seconds summary
tomcat_global_request_seconds_count{application="path-connector-globalcu",name="http-nio-3009"} 0
tomcat_global_request_seconds_sum{application="path-connector-globalcu",name="http-nio-3009"} 0.0
# HELP tomcat_global_sent_bytes_total  
# TYPE tomcat_global_sent_bytes_total counter
tomcat_global_sent_bytes_total{application="path-connector-globalcu",name="http-nio-3009"} 0.0
# HELP tomcat_servlet_error_total  
# TYPE tomcat_servlet_error_total counter
tomcat_servlet_error_total{application="path-connector-globalcu",name="dispatcherServlet"} 0.0
# HELP tomcat_servlet_request_max_seconds  
# TYPE tomcat_servlet_request_max_seconds gauge
tomcat_servlet_request_max_seconds{application="path-connector-globalcu",name="dispatcherServlet"} 0.0
# HELP tomcat_servlet_request_seconds  
# TYPE tomcat_servlet_request_seconds summary
tomcat_servlet_request_seconds_count{application="path-connector-globalcu",name="dispatcherServlet"} 1
tomcat_servlet_request_seconds_sum{application="path-connector-globalcu",name="dispatcherServlet"} 0.0
# HELP tomcat_sessions_active_current_sessions  
# TYPE tomcat_sessions_active_current_sessions gauge
tomcat_sessions_active_current_sessions{application="path-connector-globalcu"} 0.0
# HELP tomcat_sessions_active_max_sessions  
# TYPE tomcat_sessions_active_max_sessions gauge
tomcat_sessions_active_max_sessions{application="path-connector-globalcu"} 0.0
# HELP tomcat_sessions_alive_max_seconds  
# TYPE tomcat_sessions_alive_max_seconds gauge
tomcat_sessions_alive_max_seconds{application="path-connector-globalcu"} 0.0
# HELP tomcat_sessions_created_sessions_total  
# TYPE tomcat_sessions_created_sessions_total counter
tomcat_sessions_created_sessions_total{application="path-connector-globalcu"} 0.0
# HELP tomcat_sessions_expired_sessions_total  
# TYPE tomcat_sessions_expired_sessions_total counter
tomcat_sessions_expired_sessions_total{application="path-connector-globalcu"} 0.0
# HELP tomcat_sessions_rejected_sessions_total  
# TYPE tomcat_sessions_rejected_sessions_total counter
tomcat_sessions_rejected_sessions_total{application="path-connector-globalcu"} 0.0
# HELP tomcat_threads_busy_threads  
# TYPE tomcat_threads_busy_threads gauge
tomcat_threads_busy_threads{application="path-connector-globalcu",name="http-nio-3009"} 1.0
# HELP tomcat_threads_config_max_threads  
# TYPE tomcat_threads_config_max_threads gauge
tomcat_threads_config_max_threads{application="path-connector-globalcu",name="http-nio-3009"} 200.0
# HELP tomcat_threads_current_threads  
# TYPE tomcat_threads_current_threads gauge
tomcat_threads_current_threads{application="path-connector-globalcu",name="http-nio-3009"} 10.0
```
</details>

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works


[GCU-1340]: https://mxcom.atlassian.net/browse/GCU-1340?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ