### PR TITLE
fix: restore versioned list payments and recurring payments

### DIFF
--- a/mdx-models/src/main/java/com/mx/path/model/mdx/accessor/payment/PaymentBaseAccessor.java
+++ b/mdx-models/src/main/java/com/mx/path/model/mdx/accessor/payment/PaymentBaseAccessor.java
@@ -195,6 +195,17 @@ public abstract class PaymentBaseAccessor extends Accessor {
   }
 
   /**
+   * List all payments - Version 20260427
+   *
+   * @return
+   */
+  @GatewayAPI
+  @API(description = "List all payments version 20260427")
+  public AccessorResponse<MdxList<Payment>> list20260427() {
+    throw new AccessorMethodNotImplementedException();
+  }
+
+  /**
    * Accessor for bill operations
    *
    * @return accessor

--- a/mdx-models/src/main/java/com/mx/path/model/mdx/accessor/payment/RecurringPaymentBaseAccessor.java
+++ b/mdx-models/src/main/java/com/mx/path/model/mdx/accessor/payment/RecurringPaymentBaseAccessor.java
@@ -79,6 +79,17 @@ public abstract class RecurringPaymentBaseAccessor extends Accessor {
   }
 
   /**
+   * List all recurring payments - Version 20260427
+   *
+   * @return
+   */
+  @GatewayAPI
+  @API(description = "List all payments version 20260427")
+  public AccessorResponse<MdxList<RecurringPayment>> list20260427() {
+    throw new AccessorMethodNotImplementedException();
+  }
+
+  /**
    * Cancel a recurring payment
    *
    * @param id

--- a/mdx-web/src/main/java/com/mx/path/model/mdx/web/controller/PaymentsController.java
+++ b/mdx-web/src/main/java/com/mx/path/model/mdx/web/controller/PaymentsController.java
@@ -90,10 +90,19 @@ public class PaymentsController extends BaseController {
     return new ResponseEntity<>(response.getResult().wrapped(), createMultiMapForResponse(response.getHeaders()), HttpStatus.OK);
   }
 
+  @SuppressWarnings({ "MagicNumber", "unchecked" })
   @RequestMapping(value = "/payments", method = RequestMethod.GET)
-  public final ResponseEntity<MdxList<Payment>> getPaymentList() {
-    AccessorResponse<MdxList<Payment>> response = gateway().payments().list();
-    return new ResponseEntity<>(response.getResult().wrapped(), createMultiMapForResponse(response.getHeaders()), HttpStatus.OK);
+  public final ResponseEntity<MdxList<Payment>> getPaymentList(HttpServletRequest request) {
+    return (ResponseEntity<MdxList<Payment>>) versioned(request)
+        .defaultVersion(MdxList.class, MdxList.class, payments -> {
+          AccessorResponse<MdxList<Payment>> response = gateway().payments().list();
+          return new ResponseEntity<>(response.getResult().wrapped(), createMultiMapForResponse(response.getHeaders()), HttpStatus.OK);
+        })
+        .version(20260427, MdxList.class, MdxList.class, payments -> {
+          AccessorResponse<MdxList<Payment>> response = gateway().payments().list20260427();
+          return new ResponseEntity<>(response.getResult().wrapped(), createMultiMapForResponse(response.getHeaders()), HttpStatus.OK);
+        })
+        .execute();
   }
 
   @RequestMapping(value = "/payments/{id}", method = RequestMethod.GET)

--- a/mdx-web/src/main/java/com/mx/path/model/mdx/web/controller/RecurringPaymentsController.java
+++ b/mdx-web/src/main/java/com/mx/path/model/mdx/web/controller/RecurringPaymentsController.java
@@ -13,6 +13,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
 
+import jakarta.servlet.http.HttpServletRequest;
+
 @RestController
 @RequestMapping(value = "{clientId}", produces = BaseController.MDX_MEDIA)
 public class RecurringPaymentsController extends BaseController {
@@ -23,10 +25,19 @@ public class RecurringPaymentsController extends BaseController {
     return new ResponseEntity<>(response.getResult().wrapped(), createMultiMapForResponse(response.getHeaders()), HttpStatus.OK);
   }
 
+  @SuppressWarnings({ "MagicNumber", "unchecked" })
   @RequestMapping(value = "/users/{userId}/recurring_payments", method = RequestMethod.GET)
-  public final ResponseEntity<MdxList<RecurringPayment>> getRecurringPayments() {
-    AccessorResponse<MdxList<RecurringPayment>> response = gateway().payments().recurring().list();
-    return new ResponseEntity<>(response.getResult().wrapped(), createMultiMapForResponse(response.getHeaders()), HttpStatus.OK);
+  public final ResponseEntity<MdxList<RecurringPayment>> getRecurringPayments(HttpServletRequest request) {
+    return (ResponseEntity<MdxList<RecurringPayment>>) versioned(request)
+        .defaultVersion(MdxList.class, MdxList.class, recurringPayments -> {
+          AccessorResponse<MdxList<RecurringPayment>> response = gateway().payments().recurring().list();
+          return new ResponseEntity<>(response.getResult().wrapped(), createMultiMapForResponse(response.getHeaders()), HttpStatus.OK);
+        })
+        .version(20260427, MdxList.class, MdxList.class, recurringPayments -> {
+          AccessorResponse<MdxList<RecurringPayment>> response = gateway().payments().recurring().list20260427();
+          return new ResponseEntity<>(response.getResult().wrapped(), createMultiMapForResponse(response.getHeaders()), HttpStatus.OK);
+        })
+        .execute();
   }
 
   @RequestMapping(value = "/users/{userId}/recurring_payments", method = RequestMethod.POST, consumes = MDX_MEDIA)

--- a/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/PaymentsControllerTest.groovy
+++ b/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/PaymentsControllerTest.groovy
@@ -68,17 +68,36 @@ class PaymentsControllerTest extends Specification {
     BaseController.setGateway(gateway)
 
     def payment = new Payment()
-    def payments = new MdxList<>().tap { add(payment) }
+    def payments = new MdxList<Payment>().tap { add(payment) }
 
     when:
     Mockito.doReturn(new AccessorResponse<MdxList<Payment>>().withResult(payments)).when(paymentGateway).list()
-    def response = subject.getPaymentList()
+    def response = subject.getPaymentList(buildRequest(null, "application/vnd.mx.mdx.v6+json"))
 
     then:
+    response.body == payments
     HttpStatus.OK == response.getStatusCode()
-    response.getBody() == payments
     verify(paymentGateway).list() || true
   }
+
+
+  def "getPayments v20260427 interacts with gateway"() {
+    given:
+    BaseController.setGateway(gateway)
+
+    def payment = new Payment()
+    def payments = new MdxList<Payment>().tap { add(payment) }
+
+    when:
+    Mockito.doReturn(new AccessorResponse<MdxList<Payment>>().withResult(payments)).when(paymentGateway).list20260427()
+    def response = subject.getPaymentList(buildRequest(null, "application/vnd.mx.mdx.v6+json;version=20260427"))
+
+    then:
+    response.getBody() == payments
+    HttpStatus.OK == response.getStatusCode()
+    verify(paymentGateway).list20260427() || true
+  }
+
 
   def "createPayment interacts with gateway"() {
     given:

--- a/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/RecurringPaymentsControllerTest.groovy
+++ b/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/RecurringPaymentsControllerTest.groovy
@@ -1,14 +1,20 @@
 package com.mx.path.model.mdx.web.controller
 
+import static org.mockito.Mockito.mock
 import static org.mockito.Mockito.spy
 import static org.mockito.Mockito.verify
+import static org.mockito.Mockito.when
 
+import com.google.gson.Gson
+import com.google.gson.GsonBuilder
+import com.mx.path.core.context.Session
 import com.mx.path.gateway.accessor.AccessorResponse
 import com.mx.path.gateway.api.Gateway
 import com.mx.path.gateway.api.payment.PaymentGateway
 import com.mx.path.gateway.api.payment.RecurringPaymentGateway
 import com.mx.path.model.mdx.model.Frequency
 import com.mx.path.model.mdx.model.MdxList
+import com.mx.path.model.mdx.model.Resources
 import com.mx.path.model.mdx.model.payment.RecurringPayment
 
 import org.mockito.Mockito
@@ -16,17 +22,24 @@ import org.springframework.http.HttpStatus
 
 import spock.lang.Specification
 
+import jakarta.servlet.http.HttpServletRequest
+
 class RecurringPaymentsControllerTest extends Specification {
   RecurringPaymentsController subject
   Gateway gateway
   PaymentGateway paymentGateway
   RecurringPaymentGateway recurringPaymentGateway
+  Gson gson
 
   def setup() {
     subject = new RecurringPaymentsController()
     recurringPaymentGateway = spy(RecurringPaymentGateway.builder().build())
     paymentGateway = PaymentGateway.builder().recurring(recurringPaymentGateway).build()
     gateway = Gateway.builder().payments(paymentGateway).build()
+
+    GsonBuilder builder = new GsonBuilder()
+    Resources.registerResources(builder)
+    gson = builder.create()
   }
 
   def cleanup() {
@@ -58,11 +71,27 @@ class RecurringPaymentsControllerTest extends Specification {
 
     when:
     Mockito.doReturn(new AccessorResponse<MdxList<RecurringPayment>>().withResult(recurringPayments)).when(recurringPaymentGateway).list()
-    def response = subject.getRecurringPayments()
+    def response = subject.getRecurringPayments(buildRequest(null, "application/vnd.mx.mdx.v6+json"))
 
     then:
+    response.body == recurringPayments
     verify(recurringPaymentGateway).list() || true
-    response.getBody() == recurringPayments
+  }
+
+  def "index recurring payments v20260427 invokes gateway"() {
+    given:
+    RecurringPayment recurringPayment = new RecurringPayment()
+    MdxList<RecurringPayment> recurringPayments = new MdxList<>()
+    recurringPayments.add(recurringPayment)
+    BaseController.setGateway(gateway)
+
+    when:
+    Mockito.doReturn(new AccessorResponse<MdxList<RecurringPayment>>().withResult(recurringPayments)).when(recurringPaymentGateway).list20260427()
+    def response = subject.getRecurringPayments(buildRequest(null, "application/vnd.mx.mdx.v6+json;version=20260427"))
+
+    then:
+    response.body == recurringPayments
+    verify(recurringPaymentGateway).list20260427() || true
   }
 
   def "get recurring payment invokes gateway"() {
@@ -89,6 +118,7 @@ class RecurringPaymentsControllerTest extends Specification {
     def response = subject.createRecurringPayment(recurringPayment)
 
     then:
+    response.body instanceof RecurringPayment
     verify(recurringPaymentGateway).create(recurringPayment) || true
     response.getBody() == recurringPayment
     HttpStatus.OK == response.getStatusCode()
@@ -125,5 +155,17 @@ class RecurringPaymentsControllerTest extends Specification {
     then:
     verify(recurringPaymentGateway).cancel(recurringPayment.id) || true
     HttpStatus.NO_CONTENT == response.getStatusCode()
+  }
+
+  def buildRequest(Object body, String contentType) {
+    HttpServletRequest request = mock(HttpServletRequest.class)
+    when(request.getReader()).thenReturn(new BufferedReader(new StringReader(gson.toJson(body))))
+    if (Session.current() != null) {
+      when(request.getHeader("mx-session-key")).thenReturn(Session.current().getId())
+    }
+    when(request.getHeaders("Content-Type")).thenReturn(Collections.enumeration([contentType]))
+    when(request.getHeaders("Accept")).thenReturn(Collections.enumeration([contentType]))
+
+    return request
   }
 }


### PR DESCRIPTION
# Summary of Changes

Restore list version endpoints for recurring payments and payments. I had to add a cast to the return value so that the xml serializer understands that it is a MdxList<Payment> or MdxList<RecurringPayment>

Fixes # https://mxcom.atlassian.net/browse/GCU-1345

## Public API Additions/Changes

Adds a versioned endpoint for list payment and recurring payment

## Downstream Consumer Impact

None. Services that currently have this feature should be getting the default behavior

# How Has This Been Tested?

Created a local snapshot and tested

<details>
  <summary>List payments</summary>

```
GET http://localhost:3009/globalcu/users/U-00u3la36x0bbNvPud1d7/payments
Accept: application/vnd.mx.mdx.v6+json
mx-feature: payments
mx-session-key: 1964e442-7332-4179-aad6-2fcf9818062c
User-Agent: IntelliJ HTTP Client/IntelliJ IDEA 2026.2.1
Accept-Encoding: br, deflate, gzip, x-gzip
Cookie: JSESSIONID=904854845A6123A5D49269722C804483
host: localhost:3009
content-length: 0

HTTP/1.1 200 
Content-Type: application/vnd.mx.mdx.v6+json;charset=UTF-8
Content-Length: 376
Date: Mon, 17 Aug 2026 21:51:31 GMT

{
  "payments": [
    {
      "account_id": "A-1504331-S-70",
      "amount": 5.0,
      "confirmation_id": "97196883",
      "deliver_on": "2026-04-15",
      "id": "2287868051",
      "memo": "",
      "payee_id": "155353959",
      "payee_name": "John 18711736",
      "sent_on": "2026-04-06",
      "status": "QUEUED",
      "user_id": "U-00u3la36x0bbNvPud1d7"
    }
  ]
```

</details>

<details>
  <summary>List payments v20260427</summary>

```
GET http://localhost:3009/globalcu/users/U-00u3la36x0bbNvPud1d7/payments
Accept: application/vnd.mx.mdx.v6+json;version=20260427
mx-feature: payments
mx-session-key: 1964e442-7332-4179-aad6-2fcf9818062c
User-Agent: IntelliJ HTTP Client/IntelliJ IDEA 2026.2.1
Accept-Encoding: br, deflate, gzip, x-gzip
Cookie: JSESSIONID=904854845A6123A5D49269722C804483
host: localhost:3009
content-length: 0

HTTP/1.1 200 
Content-Type: application/vnd.mx.mdx.v6+json;version=20260427;charset=UTF-8
Content-Length: 744
Date: Mon, 17 Aug 2026 21:57:34 GMT

{
  "payments": [
    {
      "account_id": "A-1504331-S-70",
      "amount": 7.04,
      "confirmation_id": "96495149",
      "deliver_on": "2078-01-09",
      "id": "16089763",
      "memo": "Updated memo",
      "payee_id": "155353959",
      "payee_name": "John 18711736",
      "sent_on": "2077-12-30",
      "status": "SUBMITTED",
      "user_id": "U-00u3la36x0bbNvPud1d7"
    },
    {
      "account_id": "A-1504331-S-70",
      "amount": 5.0,
      "confirmation_id": "97196883",
      "deliver_on": "2026-04-15",
      "id": "2287868051",
      "memo": "",
      "payee_id": "155353959",
      "payee_name": "John 18711736",
      "sent_on": "2026-04-06",
      "status": "QUEUED",
      "user_id": "U-00u3la36x0bbNvPud1d7"
    }
  ]
}
```

</details>

<details>
  <summary>List recurring payments</summary>

```
GET http://localhost:3009/globalcu/users/U-00u3la36x0bbNvPud1d7/recurring_payments
Accept: application/vnd.mx.mdx.v6+json
mx-feature: payments
mx-session-key: 1964e442-7332-4179-aad6-2fcf9818062c
User-Agent: IntelliJ HTTP Client/IntelliJ IDEA 2026.2.1
Accept-Encoding: br, deflate, gzip, x-gzip
Cookie: JSESSIONID=904854845A6123A5D49269722C804483
host: localhost:3009
content-length: 0

HTTP/1.1 200 
Content-Type: application/vnd.mx.mdx.v6+json;charset=UTF-8
Content-Length: 459
Date: Mon, 17 Aug 2026 21:58:13 GMT

{
  "recurring_payments": [
    {
      "id": "16089763",
      "confirmation_id": "96495149",
      "account_id": "A-1504331-S-70",
      "payee_id": "155353959",
      "payee_name": "John 18711736",
      "frequency_id": "DEFAULT",
      "status": "ACTIVE",
      "amount": 7.04,
      "memo": "Updated memo",
      "end_after_count": 1,
      "payments_count": 0,
      "next_payment_on": "2078-01-09",
      "user_id": "U-00u3la36x0bbNvPud1d7"
    }
  ]
}
```

</details>

<details>
  <summary>List recurring payments v20260427</summary>

```
GET http://localhost:3009/globalcu/users/U-00u3la36x0bbNvPud1d7/recurring_payments
Accept: application/vnd.mx.mdx.v6+json;version=20260427
mx-feature: payments
mx-session-key: 1964e442-7332-4179-aad6-2fcf9818062c
User-Agent: IntelliJ HTTP Client/IntelliJ IDEA 2026.2.1
Accept-Encoding: br, deflate, gzip, x-gzip
Cookie: JSESSIONID=904854845A6123A5D49269722C804483
host: localhost:3009
content-length: 0

HTTP/1.1 200 
Content-Type: application/vnd.mx.mdx.v6+json;version=20260427;charset=UTF-8
Content-Length: 30
Date: Mon, 17 Aug 2026 21:59:23 GMT

{
  "recurring_payments": []
}
```

</details>

<details>
  <summary>GCU payment arsenal tests passing</summary>

```
Request 'Authenticate' POST http://localhost:3009/globalcu/authentications
Request 'List payment accounts' GET http://localhost:3009/globalcu/users/U-00u3la36x0bbNvPud1d7/accounts/payment
Request 'List merchants' GET http://localhost:3009/globalcu/merchants?name=comcast
Request 'Create payee' POST http://localhost:3009/globalcu/users/U-00u3la36x0bbNvPud1d7/payees
Request 'Create merchant payee' POST http://localhost:3009/globalcu/users/U-00u3la36x0bbNvPud1d7/payees
Request 'List payees' GET http://localhost:3009/globalcu/users/U-00u3la36x0bbNvPud1d7/payees
Request 'Get payee' GET http://localhost:3009/globalcu/users/U-00u3la36x0bbNvPud1d7/payees/156357425
Request 'Update payee' PUT http://localhost:3009/globalcu/users/U-00u3la36x0bbNvPud1d7/payees/156357425
Request 'Update merchant payee' PUT http://localhost:3009/globalcu/users/U-00u3la36x0bbNvPud1d7/payees/156357426
Request 'List recurring payment frequencies' GET http://localhost:3009/globalcu/recurring_payments/frequencies
Request 'Create recurring payment' POST http://localhost:3009/globalcu/users/U-00u3la36x0bbNvPud1d7/recurring_payments
Request 'List recurring payments' GET http://localhost:3009/globalcu/users/U-00u3la36x0bbNvPud1d7/recurring_payments
Request 'Get recurring payment' GET http://localhost:3009/globalcu/users/U-00u3la36x0bbNvPud1d7/recurring_payments/17043587
Request 'Update recurring payment' PUT http://localhost:3009/globalcu/users/U-00u3la36x0bbNvPud1d7/recurring_payments/17043587
Request 'Update recurring payment to one time' PUT http://localhost:3009/globalcu/users/U-00u3la36x0bbNvPud1d7/recurring_payments/17043587
Request 'Cancel recurring payment' PUT http://localhost:3009/globalcu/users/U-00u3la36x0bbNvPud1d7/recurring_payments/17043587/cancel
Request 'Ensure recurring payment is cancelled' GET http://localhost:3009/globalcu/users/U-00u3la36x0bbNvPud1d7/recurring_payments
Request 'Create payment' POST http://localhost:3009/globalcu/users/U-00u3la36x0bbNvPud1d7/payments
Request 'List payments' GET http://localhost:3009/globalcu/users/U-00u3la36x0bbNvPud1d7/payments
Request 'Update payment' PUT http://localhost:3009/globalcu/users/U-00u3la36x0bbNvPud1d7/payments/17043588
Request 'Cancel payment' PUT http://localhost:3009/globalcu/users/U-00u3la36x0bbNvPud1d7/payments/17043588/cancel
Request 'Ensure payment is cancelled' GET http://localhost:3009/globalcu/users/U-00u3la36x0bbNvPud1d7/payments
Request 'Delete payee' DELETE http://localhost:3009/globalcu/users/U-00u3la36x0bbNvPud1d7/payees/156357425
Request 'Ensure payee is deleted' GET http://localhost:3009/globalcu/users/U-00u3la36x0bbNvPud1d7/payees
Request 'Delete merchant payee' DELETE http://localhost:3009/globalcu/users/U-00u3la36x0bbNvPud1d7/payees/156357426
Request 'Ensure merchant payee is deleted' GET http://localhost:3009/globalcu/users/U-00u3la36x0bbNvPud1d7/payees
Request 'Log out' DELETE http://localhost:3009/globalcu/authentications/e5f4f3d0-1d17-42c0-9315-881d803ce09a


27 requests completed, 0 have failed tests
RUN SUCCESSFUL
```

</details>



# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
