### PR TITLE
fix(achtransfer): add confirmation_id to AchTransfer

### DIFF
--- a/mdx-gateways/src/test/groovy/com/mx/path/gateway/BaseMdxGatewayTest.groovy
+++ b/mdx-gateways/src/test/groovy/com/mx/path/gateway/BaseMdxGatewayTest.groovy
@@ -115,7 +115,7 @@ class BaseMdxGatewayTest extends Specification {
 
     when:
     def accounts = new AccountGateway()
-    subject.setAccounts (accounts)
+    subject.setAccounts(accounts)
 
     then:
     subject.gateways().size() == 1

--- a/mdx-gateways/src/test/groovy/com/mx/path/gateway/GatewayConfiguratorTest.groovy
+++ b/mdx-gateways/src/test/groovy/com/mx/path/gateway/GatewayConfiguratorTest.groovy
@@ -123,7 +123,7 @@ class GatewayConfiguratorTest extends Specification {
     assert result["clientName"].behaviors.get(0).getClass().canonicalName == "com.mx.testing.GatewayBehaviorImpl"
     assert result["clientName"].id().behaviors.size() == 2
     assert result["clientName"].id().behaviors.get(0).getClass().canonicalName == "com.mx.testing.GatewayBehaviorImpl"
-    assert result["clientName"].id().behaviors.get(1).getClass().canonicalName =="com.mx.testing.MDXGatewayBehaviorImpl"
+    assert result["clientName"].id().behaviors.get(1).getClass().canonicalName == "com.mx.testing.MDXGatewayBehaviorImpl"
   }
 
   def "build gateway with child accessor annotations"() {
@@ -134,7 +134,9 @@ class GatewayConfiguratorTest extends Specification {
     def baseAccessorConf = objectMap.createMap("accessor")
     baseAccessorConf.put("class", ChildAccessorBase.class.getCanonicalName())
     baseAccessorConf.put("scope", "singleton")
-    baseAccessorConf.put("configurations", new ObjectMap().tap { put("Wakirimasu ka?", "Hai!") })
+    baseAccessorConf.put("configurations", new ObjectMap().tap {
+      put("Wakirimasu ka?", "Hai!")
+    })
     baseAccessorConf.put("connections", new ObjectMap().tap {
       put("MyConnection", new ObjectMap().tap {
         put("baseUrl", "https://example.com")

--- a/mdx-models/src/main/java/com/mx/path/model/mdx/model/ach_transfer/AchTransfer.java
+++ b/mdx-models/src/main/java/com/mx/path/model/mdx/model/ach_transfer/AchTransfer.java
@@ -13,8 +13,8 @@ import com.mx.path.model.mdx.model.account.Account;
 public final class AchTransfer extends MdxBase<AchTransfer> {
   private String id;
   private String achScheduledTransferId;
-  private String confirmationId;
   private Double amount;
+  private String confirmationId;
   private Long createdAt;
   @Getter(onMethod_ = { @MdxRelationId(referredClass = Account.class) })
   private String fromAccountId;

--- a/mdx-models/src/main/java/com/mx/path/model/mdx/model/ach_transfer/AchTransfer.java
+++ b/mdx-models/src/main/java/com/mx/path/model/mdx/model/ach_transfer/AchTransfer.java
@@ -13,6 +13,7 @@ import com.mx.path.model.mdx.model.account.Account;
 public final class AchTransfer extends MdxBase<AchTransfer> {
   private String id;
   private String achScheduledTransferId;
+  private String confirmationId;
   private Double amount;
   private Long createdAt;
   @Getter(onMethod_ = { @MdxRelationId(referredClass = Account.class) })

--- a/mdx-models/src/test/groovy/com/mx/path/model/mdx/accessor/BaseAccessorTest.groovy
+++ b/mdx-models/src/test/groovy/com/mx/path/model/mdx/accessor/BaseAccessorTest.groovy
@@ -22,7 +22,9 @@ class BaseAccessorTest extends Specification {
 
     then: "It contains accessors for implemented AccountBaseTestAccessor AND StatusBaseAccessor"
     result.size() == 2
-    result.any({it.accessorClass == BaseAccessorTestImplemented.AccountBaseTestAccessor})
+    result.any({
+      it.accessorClass == BaseAccessorTestImplemented.AccountBaseTestAccessor
+    })
     result.any({it.accessorClass == StatusDefaultAccessor })
     result[0].base.accessorClass == BaseAccessor
     result.every({ it.base.accessorClass == BaseAccessor })

--- a/mdx-models/src/test/groovy/com/mx/path/model/mdx/model/MdxLogMaskerTest.groovy
+++ b/mdx-models/src/test/groovy/com/mx/path/model/mdx/model/MdxLogMaskerTest.groovy
@@ -13,7 +13,7 @@ class MdxLogMaskerTest extends Specification {
     result == expectedResult
 
     where:
-    header             || expectedResult
+    header || expectedResult
     "mx-refresh-token" || "**MASKED**"
   }
 
@@ -26,12 +26,12 @@ class MdxLogMaskerTest extends Specification {
     result == expectedResult
 
     where:
-    payload                                      || expectedResult
-    "\"account_number\":\"1234567890\""          || "\"account_number\":\"**MASKED**\""
-    "\"id\":\"ACCOUNT-123\""                     || "\"id\":\"**MASKED**\""
-    "\"name\":\"Checking Account\""              || "\"name\":\"**MASKED**\""
-    "\"nickname\":\"My Checking\""               || "\"nickname\":\"**MASKED**\""
-    "\"routing_number\":\"121122676\""           || "\"routing_number\":\"**MASKED**\""
+    payload || expectedResult
+    "\"account_number\":\"1234567890\"" || "\"account_number\":\"**MASKED**\""
+    "\"id\":\"ACCOUNT-123\"" || "\"id\":\"**MASKED**\""
+    "\"name\":\"Checking Account\"" || "\"name\":\"**MASKED**\""
+    "\"nickname\":\"My Checking\"" || "\"nickname\":\"**MASKED**\""
+    "\"routing_number\":\"121122676\"" || "\"routing_number\":\"**MASKED**\""
     "\"routing_transit_number\":\"0260-0959-3\"" || "\"routing_transit_number\":\"**MASKED**\""
   }
 
@@ -44,12 +44,12 @@ class MdxLogMaskerTest extends Specification {
     result == expectedResult
 
     where:
-    payload                                                        || expectedResult
-    "<account_number>1234567890</account_number>"                  || "<account_number>**MASKED**</account_number>"
-    "<id>ACCOUNT-123</id>"                                         || "<id>**MASKED**</id>"
-    "<name>Checking Account</name>"                                || "<name>**MASKED**</name>"
-    "<nickname>My Checking</nickname>"                             || "<nickname>**MASKED**</nickname>"
-    "<routing_number>121122676</routing_number>"                   || "<routing_number>**MASKED**</routing_number>"
+    payload || expectedResult
+    "<account_number>1234567890</account_number>" || "<account_number>**MASKED**</account_number>"
+    "<id>ACCOUNT-123</id>" || "<id>**MASKED**</id>"
+    "<name>Checking Account</name>" || "<name>**MASKED**</name>"
+    "<nickname>My Checking</nickname>" || "<nickname>**MASKED**</nickname>"
+    "<routing_number>121122676</routing_number>" || "<routing_number>**MASKED**</routing_number>"
     "<routing_transit_number>0260-0959-3</routing_transit_number>" || "<routing_transit_number>**MASKED**</routing_transit_number>"
   }
 
@@ -62,7 +62,7 @@ class MdxLogMaskerTest extends Specification {
     result == expectedResult
 
     where:
-    payload                                                                                                                          || expectedResult
+    payload || expectedResult
     "\"extended_fields\":[{\n    \"type\": \"STRING\",\n    \"name\": \"secret field\",\n    \"string_value\": \"secret value\"\n}]" || "\"extended_fields\":[**MASKED**]"
   }
 
@@ -75,9 +75,9 @@ class MdxLogMaskerTest extends Specification {
     result == expectedResult
 
     where:
-    payload                             || expectedResult
+    payload || expectedResult
     "\"account_number\":\"1234567890\"" || "\"account_number\":\"**MASKED**\""
-    "\"routing_number\":\"121122676\""  || "\"routing_number\":\"**MASKED**\""
+    "\"routing_number\":\"121122676\"" || "\"routing_number\":\"**MASKED**\""
   }
 
   @Unroll
@@ -89,14 +89,14 @@ class MdxLogMaskerTest extends Specification {
     result == expectedResult
 
     where:
-    payload                                        || expectedResult
+    payload || expectedResult
     "\"address\":\"3401 N Thanksgiving Way #500\"" || "\"address\":\"**MASKED**\""
-    "\"city\":\"Lehi\""                            || "\"city\":\"**MASKED**\""
-    "\"email\":\"john.doe@example.com\""           || "\"email\":\"**MASKED**\""
-    "\"owner_name\":\"John Doe\""                  || "\"owner_name\":\"**MASKED**\""
-    "\"phone\":\"1-222-333-4444\""                 || "\"phone\":\"**MASKED**\""
-    "\"zip_code\":\"84043\""                       || "\"zip_code\":\"**MASKED**\""
-    "\"state\":\"UT\""                             || "\"state\":\"**MASKED**\""
+    "\"city\":\"Lehi\"" || "\"city\":\"**MASKED**\""
+    "\"email\":\"john.doe@example.com\"" || "\"email\":\"**MASKED**\""
+    "\"owner_name\":\"John Doe\"" || "\"owner_name\":\"**MASKED**\""
+    "\"phone\":\"1-222-333-4444\"" || "\"phone\":\"**MASKED**\""
+    "\"zip_code\":\"84043\"" || "\"zip_code\":\"**MASKED**\""
+    "\"state\":\"UT\"" || "\"state\":\"**MASKED**\""
   }
 
   @Unroll
@@ -108,9 +108,9 @@ class MdxLogMaskerTest extends Specification {
     result == expectedResult
 
     where:
-    payload                                            || expectedResult
+    payload || expectedResult
     "\"description\":\"3401 N Thanksgiving Way #500\"" || "\"description\":\"**MASKED**\""
-    "\"target\":\"Email - *1@example.com\""            || "\"target\":\"**MASKED**\""
+    "\"target\":\"Email - *1@example.com\"" || "\"target\":\"**MASKED**\""
   }
 
   @Unroll
@@ -122,12 +122,12 @@ class MdxLogMaskerTest extends Specification {
     result == expectedResult
 
     where:
-    payload                                || expectedResult
-    "\"account_id\":\"ACCOUNT-123\""       || "\"account_id\":\"**MASKED**\""
-    "\"check_number\":\"1234\""            || "\"check_number\":\"**MASKED**\""
+    payload || expectedResult
+    "\"account_id\":\"ACCOUNT-123\"" || "\"account_id\":\"**MASKED**\""
+    "\"check_number\":\"1234\"" || "\"check_number\":\"**MASKED**\""
     "\"description\":\"Test transaction\"" || "\"description\":\"**MASKED**\""
-    "\"id\":\"TRANSACTION-123\""           || "\"id\":\"**MASKED**\""
-    "\"memo\":\"Test memo\""               || "\"memo\":\"**MASKED**\""
+    "\"id\":\"TRANSACTION-123\"" || "\"id\":\"**MASKED**\""
+    "\"memo\":\"Test memo\"" || "\"memo\":\"**MASKED**\""
   }
 
   @Unroll
@@ -139,12 +139,12 @@ class MdxLogMaskerTest extends Specification {
     result == expectedResult
 
     where:
-    payload                                       || expectedResult
-    "<account_id>ACCOUNT-123</account_id>"        || "<account_id>**MASKED**</account_id>"
-    "<check_number>1234</check_number>"           || "<check_number>**MASKED**</check_number>"
+    payload || expectedResult
+    "<account_id>ACCOUNT-123</account_id>" || "<account_id>**MASKED**</account_id>"
+    "<check_number>1234</check_number>" || "<check_number>**MASKED**</check_number>"
     "<description>Test transaction</description>" || "<description>**MASKED**</description>"
-    "<id>TRANSACTION-123</id>"                    || "<id>**MASKED**</id>"
-    "<memo>Test memo</memo>"                      || "<memo>**MASKED**</memo>"
+    "<id>TRANSACTION-123</id>" || "<id>**MASKED**</id>"
+    "<memo>Test memo</memo>" || "<memo>**MASKED**</memo>"
   }
 
   @Unroll
@@ -156,8 +156,8 @@ class MdxLogMaskerTest extends Specification {
     result == expectedResult
 
     where:
-    payload                              || expectedResult
-    "\"account_id\":\"ACCOUNT-123\""     || "\"account_id\":\"**MASKED**\""
+    payload || expectedResult
+    "\"account_id\":\"ACCOUNT-123\"" || "\"account_id\":\"**MASKED**\""
     "\"ach_account_id\":\"ACCOUNT-456\"" || "\"ach_account_id\":\"**MASKED**\""
   }
 
@@ -170,14 +170,14 @@ class MdxLogMaskerTest extends Specification {
     result == expectedResult
 
     where:
-    payload                               || expectedResult
-    "\"account_id\":\"ACCOUNT-123\""      || "\"account_id\":\"**MASKED**\""
-    "\"account_number\":\"1234567890\""   || "\"account_number\":\"**MASKED**\""
+    payload || expectedResult
+    "\"account_id\":\"ACCOUNT-123\"" || "\"account_id\":\"**MASKED**\""
+    "\"account_number\":\"1234567890\"" || "\"account_number\":\"**MASKED**\""
     "\"bank_name\":\"Test Credit Union\"" || "\"bank_name\":\"**MASKED**\""
-    "\"id\":\"ACH-ACCOUNT-123\""          || "\"id\":\"**MASKED**\""
-    "\"name\":\"Test Name\""              || "\"name\":\"**MASKED**\""
-    "\"nickname\":\"Test Nickname\""      || "\"nickname\":\"**MASKED**\""
-    "\"routing_number\":\"121122676\""    || "\"routing_number\":\"**MASKED**\""
+    "\"id\":\"ACH-ACCOUNT-123\"" || "\"id\":\"**MASKED**\""
+    "\"name\":\"Test Name\"" || "\"name\":\"**MASKED**\""
+    "\"nickname\":\"Test Nickname\"" || "\"nickname\":\"**MASKED**\""
+    "\"routing_number\":\"121122676\"" || "\"routing_number\":\"**MASKED**\""
   }
 
   @Unroll
@@ -189,13 +189,13 @@ class MdxLogMaskerTest extends Specification {
     result == expectedResult
 
     where:
-    payload                                     || expectedResult
-    "\"from_account_id\":\"ACCOUNT-1\""         || "\"from_account_id\":\"**MASKED**\""
+    payload || expectedResult
+    "\"from_account_id\":\"ACCOUNT-1\"" || "\"from_account_id\":\"**MASKED**\""
     "\"from_ach_account_id\":\"ACH-ACCOUNT-1\"" || "\"from_ach_account_id\":\"**MASKED**\""
-    "\"id\":\"ACH-TRANSFER-1\""                 || "\"id\":\"**MASKED**\""
-    "\"memo\":\"Test ACH Transfer\""            || "\"memo\":\"**MASKED**\""
-    "\"to_account_id\":\"ACCOUNT-2\""           || "\"to_account_id\":\"**MASKED**\""
-    "\"to_ach_account_id\":\"ACH-ACCOUNT-2\""   || "\"to_ach_account_id\":\"**MASKED**\""
+    "\"id\":\"ACH-TRANSFER-1\"" || "\"id\":\"**MASKED**\""
+    "\"memo\":\"Test ACH Transfer\"" || "\"memo\":\"**MASKED**\""
+    "\"to_account_id\":\"ACCOUNT-2\"" || "\"to_account_id\":\"**MASKED**\""
+    "\"to_ach_account_id\":\"ACH-ACCOUNT-2\"" || "\"to_ach_account_id\":\"**MASKED**\""
   }
 
   @Unroll
@@ -207,13 +207,13 @@ class MdxLogMaskerTest extends Specification {
     result == expectedResult
 
     where:
-    payload                                     || expectedResult
-    "\"from_account_id\":\"ACCOUNT-1\""         || "\"from_account_id\":\"**MASKED**\""
+    payload || expectedResult
+    "\"from_account_id\":\"ACCOUNT-1\"" || "\"from_account_id\":\"**MASKED**\""
     "\"from_ach_account_id\":\"ACH-ACCOUNT-1\"" || "\"from_ach_account_id\":\"**MASKED**\""
-    "\"id\":\"ACH-TRANSFER-1\""                 || "\"id\":\"**MASKED**\""
-    "\"memo\":\"Test ACH Transfer\""            || "\"memo\":\"**MASKED**\""
-    "\"to_account_id\":\"ACCOUNT-2\""           || "\"to_account_id\":\"**MASKED**\""
-    "\"to_ach_account_id\":\"ACH-ACCOUNT-2\""   || "\"to_ach_account_id\":\"**MASKED**\""
+    "\"id\":\"ACH-TRANSFER-1\"" || "\"id\":\"**MASKED**\""
+    "\"memo\":\"Test ACH Transfer\"" || "\"memo\":\"**MASKED**\""
+    "\"to_account_id\":\"ACCOUNT-2\"" || "\"to_account_id\":\"**MASKED**\""
+    "\"to_ach_account_id\":\"ACH-ACCOUNT-2\"" || "\"to_ach_account_id\":\"**MASKED**\""
   }
 
   @Unroll
@@ -225,13 +225,13 @@ class MdxLogMaskerTest extends Specification {
     result == expectedResult
 
     where:
-    payload                                                                         || expectedResult
-    "\"account_id\":\"ACCOUNT-1\""                                                  || "\"account_id\":\"**MASKED**\""
+    payload || expectedResult
+    "\"account_id\":\"ACCOUNT-1\"" || "\"account_id\":\"**MASKED**\""
     "\"cookies\":[{\n    \"cookie1\": \"value1\",\n    \"cookie2\": \"value2\"\n}]" || "\"cookies\":[**MASKED**]"
-    "\"device_id\":\"ACH-TRANSFER-1\""                                              || "\"device_id\":\"**MASKED**\""
+    "\"device_id\":\"ACH-TRANSFER-1\"" || "\"device_id\":\"**MASKED**\""
     "\"headers\":[{\n    \"header1\": \"value1\",\n    \"header2\": \"value2\"\n}]" || "\"headers\":[**MASKED**]"
-    "\"token\":\"j8tGkb0STI827r0aMBOvJN9tBU08nFsc8gSivZLIfBw=\""                    || "\"token\":\"**MASKED**\""
-    "\"tokens\":[{\n    \"token1\": \"value1\",\n    \"token2\": \"value2\"\n}]"    || "\"tokens\":[**MASKED**]"
+    "\"token\":\"j8tGkb0STI827r0aMBOvJN9tBU08nFsc8gSivZLIfBw=\"" || "\"token\":\"**MASKED**\""
+    "\"tokens\":[{\n    \"token1\": \"value1\",\n    \"token2\": \"value2\"\n}]" || "\"tokens\":[**MASKED**]"
     "\"url\":\"http:/test.example.com/sso?token=b1d36291310644fe921b8bdff8d08d61\"" || "\"url\":\"**MASKED**\""
   }
 
@@ -244,7 +244,7 @@ class MdxLogMaskerTest extends Specification {
     result == expectedResult
 
     where:
-    payload                      || expectedResult
+    payload || expectedResult
     "\"answer\":\"Test answer\"" || "\"answer\":\"**MASKED**\""
   }
 
@@ -257,12 +257,12 @@ class MdxLogMaskerTest extends Specification {
     result == expectedResult
 
     where:
-    payload                                                               || expectedResult
-    "\"account_id\":\"ACCOUNT-1\""                                        || "\"account_id\":\"**MASKED**\""
-    "\"back_image\":\"data:image/png;base64,iVBORw0KGAAAUAAAAFCJggg==\""  || "\"back_image\":\"**MASKED**\""
-    "\"check_number\":\"1234\""                                           || "\"check_number\":\"**MASKED**\""
+    payload || expectedResult
+    "\"account_id\":\"ACCOUNT-1\"" || "\"account_id\":\"**MASKED**\""
+    "\"back_image\":\"data:image/png;base64,iVBORw0KGAAAUAAAAFCJggg==\"" || "\"back_image\":\"**MASKED**\""
+    "\"check_number\":\"1234\"" || "\"check_number\":\"**MASKED**\""
     "\"front_image\":\"data:image/png;base64,iVBORw0KGAAAUAAAAFCJggg==\"" || "\"front_image\":\"**MASKED**\""
-    "\"transaction_id\":\"TRANSACTION-1\""                                || "\"transaction_id\":\"**MASKED**\""
+    "\"transaction_id\":\"TRANSACTION-1\"" || "\"transaction_id\":\"**MASKED**\""
   }
 
   @Unroll
@@ -274,9 +274,9 @@ class MdxLogMaskerTest extends Specification {
     result == expectedResult
 
     where:
-    payload                   || expectedResult
+    payload || expectedResult
     "\"first_name\":\"John\"" || "\"first_name\":\"**MASKED**\""
-    "\"last_name\":\"Doe\""   || "\"last_name\":\"**MASKED**\""
+    "\"last_name\":\"Doe\"" || "\"last_name\":\"**MASKED**\""
   }
 
   @Unroll
@@ -288,10 +288,10 @@ class MdxLogMaskerTest extends Specification {
     result == expectedResult
 
     where:
-    payload                                  || expectedResult
+    payload || expectedResult
     "\"destination_id\":\"DESTINATION-123\"" || "\"destination_id\":\"**MASKED**\""
-    "\"from_account_id\":\"ACCOUNT-123\""    || "\"from_account_id\":\"**MASKED**\""
-    "\"memo\":\"Test memo\""                 || "\"memo\":\"**MASKED**\""
+    "\"from_account_id\":\"ACCOUNT-123\"" || "\"from_account_id\":\"**MASKED**\""
+    "\"memo\":\"Test memo\"" || "\"memo\":\"**MASKED**\""
   }
 
   @Unroll
@@ -303,10 +303,10 @@ class MdxLogMaskerTest extends Specification {
     result == expectedResult
 
     where:
-    payload                                  || expectedResult
+    payload || expectedResult
     "\"destination_id\":\"DESTINATION-123\"" || "\"destination_id\":\"**MASKED**\""
-    "\"from_account_id\":\"ACCOUNT-123\""    || "\"from_account_id\":\"**MASKED**\""
-    "\"memo\":\"Test memo\""                 || "\"memo\":\"**MASKED**\""
+    "\"from_account_id\":\"ACCOUNT-123\"" || "\"from_account_id\":\"**MASKED**\""
+    "\"memo\":\"Test memo\"" || "\"memo\":\"**MASKED**\""
   }
 
   @Unroll
@@ -318,10 +318,10 @@ class MdxLogMaskerTest extends Specification {
     result == expectedResult
 
     where:
-    payload                                  || expectedResult
+    payload || expectedResult
     "\"destination_id\":\"DESTINATION-123\"" || "\"destination_id\":\"**MASKED**\""
-    "\"from_account_id\":\"ACCOUNT-123\""    || "\"from_account_id\":\"**MASKED**\""
-    "\"memo\":\"Test memo\""                 || "\"memo\":\"**MASKED**\""
+    "\"from_account_id\":\"ACCOUNT-123\"" || "\"from_account_id\":\"**MASKED**\""
+    "\"memo\":\"Test memo\"" || "\"memo\":\"**MASKED**\""
   }
 
   @Unroll
@@ -333,10 +333,10 @@ class MdxLogMaskerTest extends Specification {
     result == expectedResult
 
     where:
-    payload                                      || expectedResult
+    payload || expectedResult
     "\"account_holder\":\"Test account holder\"" || "\"account_holder\":\"**MASKED**\""
-    "\"account_number\":\"1234567890\""          || "\"account_number\":\"**MASKED**\""
-    "\"id\":\"ACCOUNT-123\""                     || "\"id\":\"**MASKED**\""
+    "\"account_number\":\"1234567890\"" || "\"account_number\":\"**MASKED**\""
+    "\"id\":\"ACCOUNT-123\"" || "\"id\":\"**MASKED**\""
   }
 
   @Unroll
@@ -348,9 +348,9 @@ class MdxLogMaskerTest extends Specification {
     result == expectedResult
 
     where:
-    payload                                  || expectedResult
+    payload || expectedResult
     "\"destination_id\":\"DESTINATION-123\"" || "\"destination_id\":\"**MASKED**\""
-    "\"from_account_id\":\"ACCOUNT-123\""    || "\"from_account_id\":\"**MASKED**\""
+    "\"from_account_id\":\"ACCOUNT-123\"" || "\"from_account_id\":\"**MASKED**\""
   }
 
   @Unroll
@@ -362,9 +362,9 @@ class MdxLogMaskerTest extends Specification {
     result == expectedResult
 
     where:
-    payload                                      || expectedResult
+    payload || expectedResult
     "\"email_address\":\"john.doe@example.com\"" || "\"email_address\":\"**MASKED**\""
-    "\"phone_number\":\"1-222-333-4444\""        || "\"phone_number\":\"**MASKED**\""
+    "\"phone_number\":\"1-222-333-4444\"" || "\"phone_number\":\"**MASKED**\""
   }
 
   @Unroll
@@ -376,12 +376,12 @@ class MdxLogMaskerTest extends Specification {
     result == expectedResult
 
     where:
-    payload                                                                || expectedResult
-    "\"account_id\":\"ACCOUNT-123\""                                       || "\"account_id\":\"**MASKED**\""
-    "\"card_id\":\"CARD-123\""                                             || "\"card_id\":\"**MASKED**\""
-    "\"case_number\":\"182744AAQ093\""                                     || "\"case_number\":\"**MASKED**\""
-    "\"contact_phone\":\"1-222-333-4444\""                                 || "\"contact_phone\":\"**MASKED**\""
-    "\"member_name\":\"John Doe\""                                         || "\"member_name\":\"**MASKED**\""
+    payload || expectedResult
+    "\"account_id\":\"ACCOUNT-123\"" || "\"account_id\":\"**MASKED**\""
+    "\"card_id\":\"CARD-123\"" || "\"card_id\":\"**MASKED**\""
+    "\"case_number\":\"182744AAQ093\"" || "\"case_number\":\"**MASKED**\""
+    "\"contact_phone\":\"1-222-333-4444\"" || "\"contact_phone\":\"**MASKED**\""
+    "\"member_name\":\"John Doe\"" || "\"member_name\":\"**MASKED**\""
     "\"source_image\":\"data:image/png;base64,iVBORw0KGAAAUAAAAFCJggg==\"" || "\"source_image\":\"**MASKED**\""
   }
 
@@ -394,7 +394,7 @@ class MdxLogMaskerTest extends Specification {
     result == expectedResult
 
     where:
-    payload                          || expectedResult
+    payload || expectedResult
     "\"account_id\":\"ACCOUNT-123\"" || "\"account_id\":\"**MASKED**\""
   }
 
@@ -407,8 +407,8 @@ class MdxLogMaskerTest extends Specification {
     result == expectedResult
 
     where:
-    payload                                                                   || expectedResult
-    "\"account_id\":\"ACCOUNT-123\""                                          || "\"account_id\":\"**MASKED**\""
+    payload || expectedResult
+    "\"account_id\":\"ACCOUNT-123\"" || "\"account_id\":\"**MASKED**\""
     "\"file_data\":\"data:application/pdf;base64,iVBORw0KGAAAUAAAAFCJggg==\"" || "\"file_data\":\"**MASKED**\""
   }
 
@@ -421,7 +421,7 @@ class MdxLogMaskerTest extends Specification {
     result == expectedResult
 
     where:
-    payload                          || expectedResult
+    payload || expectedResult
     "\"account_id\":\"ACCOUNT-123\"" || "\"account_id\":\"**MASKED**\""
   }
 
@@ -434,21 +434,21 @@ class MdxLogMaskerTest extends Specification {
     result == expectedResult
 
     where:
-    payload                                                          || expectedResult
-    "\"access_token\":\"167f0a358b054953ae7c9527e2d273a9\""          || "\"access_token\":\"**MASKED**\""
-    "\"client_device_token\":\"UNIQUE_TOKEN_FOR_THIS_DEVICE\""       || "\"client_device_token\":\"**MASKED**\""
-    "\"device_make\":\"Apple\""                                      || "\"device_make\":\"**MASKED**\""
-    "\"device_model\":\"iPhone X\""                                  || "\"device_model\":\"**MASKED**\""
-    "\"device_operating_system\":\"iOS\""                            || "\"device_operating_system\":\"**MASKED**\""
-    "\"device_operating_system_version\":\"11.4.1\""                 || "\"device_operating_system_version\":\"**MASKED**\""
-    "\"device_latitude\":40.4296944"                                 || "\"device_latitude\":**MASKED**"
-    "\"device_longitude\":-111.8931454"                              || "\"device_longitude\":**MASKED**"
+    payload || expectedResult
+    "\"access_token\":\"167f0a358b054953ae7c9527e2d273a9\"" || "\"access_token\":\"**MASKED**\""
+    "\"client_device_token\":\"UNIQUE_TOKEN_FOR_THIS_DEVICE\"" || "\"client_device_token\":\"**MASKED**\""
+    "\"device_make\":\"Apple\"" || "\"device_make\":\"**MASKED**\""
+    "\"device_model\":\"iPhone X\"" || "\"device_model\":\"**MASKED**\""
+    "\"device_operating_system\":\"iOS\"" || "\"device_operating_system\":\"**MASKED**\""
+    "\"device_operating_system_version\":\"11.4.1\"" || "\"device_operating_system_version\":\"**MASKED**\""
+    "\"device_latitude\":40.4296944" || "\"device_latitude\":**MASKED**"
+    "\"device_longitude\":-111.8931454" || "\"device_longitude\":**MASKED**"
     "\"device_iovation_token\":\"ac1d3a2455a9444ebc942c7842660ed2\"" || "\"device_iovation_token\":\"**MASKED**\""
-    "\"login\":\"johndoe\""                                          || "\"login\":\"**MASKED**\""
-    "\"password\":\"topsecret\""                                     || "\"password\":\"**MASKED**\""
-    "\"refresh_token\":\"2ed7c86985d0404a8728fe4c621711b5\""         || "\"refresh_token\":\"**MASKED**\""
-    "\"token\":\"b43cac3cfbcc45d4abecef87064b63ce\""                 || "\"token\":\"**MASKED**\""
-    "\"userkey\":\"25ff030acfba4cdf91618dc23b4795e4\""               || "\"userkey\":\"**MASKED**\""
+    "\"login\":\"johndoe\"" || "\"login\":\"**MASKED**\""
+    "\"password\":\"topsecret\"" || "\"password\":\"**MASKED**\""
+    "\"refresh_token\":\"2ed7c86985d0404a8728fe4c621711b5\"" || "\"refresh_token\":\"**MASKED**\""
+    "\"token\":\"b43cac3cfbcc45d4abecef87064b63ce\"" || "\"token\":\"**MASKED**\""
+    "\"userkey\":\"25ff030acfba4cdf91618dc23b4795e4\"" || "\"userkey\":\"**MASKED**\""
   }
 
   @Unroll
@@ -460,7 +460,7 @@ class MdxLogMaskerTest extends Specification {
     result == expectedResult
 
     where:
-    payload                || expectedResult
+    payload || expectedResult
     "\"answer\":\"12345\"" || "\"answer\":\"**MASKED**\""
   }
 
@@ -473,7 +473,7 @@ class MdxLogMaskerTest extends Specification {
     result == expectedResult
 
     where:
-    payload                || expectedResult
+    payload || expectedResult
     "\"answer\":\"12345\"" || "\"answer\":\"**MASKED**\""
   }
 
@@ -486,15 +486,15 @@ class MdxLogMaskerTest extends Specification {
     result == expectedResult
 
     where:
-    payload                                                           || expectedResult
-    "\"account_id\":\"ACCOUNT-123\""                                  || "\"account_id\":\"**MASKED**\""
-    "\"expiration_on_card\":\"06/97\""                                || "\"expiration_on_card\":\"**MASKED**\""
+    payload || expectedResult
+    "\"account_id\":\"ACCOUNT-123\"" || "\"account_id\":\"**MASKED**\""
+    "\"expiration_on_card\":\"06/97\"" || "\"expiration_on_card\":\"**MASKED**\""
     "\"image_url\":\"https://logos.co/customers/123/card_image.jpg\"" || "\"image_url\":\"**MASKED**\""
-    "\"name_on_card\":\"John Doe\""                                   || "\"name_on_card\":\"**MASKED**\""
-    "\"new_pin\":\"12345\""                                           || "\"new_pin\":\"**MASKED**\""
-    "\"pin\":\"12345\""                                               || "\"pin\":\"**MASKED**\""
-    "\"unmasked_cvv\":\"123\""                                        || "\"unmasked_cvv\":\"**MASKED**\""
-    "\"unmasked_number_on_card\":\"1111222233334444\""                || "\"unmasked_number_on_card\":\"**MASKED**\""
+    "\"name_on_card\":\"John Doe\"" || "\"name_on_card\":\"**MASKED**\""
+    "\"new_pin\":\"12345\"" || "\"new_pin\":\"**MASKED**\""
+    "\"pin\":\"12345\"" || "\"pin\":\"**MASKED**\""
+    "\"unmasked_cvv\":\"123\"" || "\"unmasked_cvv\":\"**MASKED**\""
+    "\"unmasked_number_on_card\":\"1111222233334444\"" || "\"unmasked_number_on_card\":\"**MASKED**\""
   }
 
   @Unroll
@@ -506,10 +506,10 @@ class MdxLogMaskerTest extends Specification {
     result == expectedResult
 
     where:
-    payload                                         || expectedResult
-    "\"card_ids\":[\"CARD_ID_1\", \"CARD_ID_2\"]"   || "\"card_ids\":[**MASKED**]"
-    "\"email_address\":\"john.doe@example.com\""    || "\"email_address\":\"**MASKED**\""
-    "\"primary_phone_number\":\"1-222-333-4444\""   || "\"primary_phone_number\":\"**MASKED**\""
+    payload || expectedResult
+    "\"card_ids\":[\"CARD_ID_1\", \"CARD_ID_2\"]" || "\"card_ids\":[**MASKED**]"
+    "\"email_address\":\"john.doe@example.com\"" || "\"email_address\":\"**MASKED**\""
+    "\"primary_phone_number\":\"1-222-333-4444\"" || "\"primary_phone_number\":\"**MASKED**\""
     "\"secondary_phone_number\":\"1-333-444-5555\"" || "\"secondary_phone_number\":\"**MASKED**\""
   }
 
@@ -522,7 +522,7 @@ class MdxLogMaskerTest extends Specification {
     result == expectedResult
 
     where:
-    payload                         || expectedResult
+    payload || expectedResult
     "\"login_token\":\"123456789\"" || "\"login_token\":\"**MASKED**\""
   }
 
@@ -535,8 +535,8 @@ class MdxLogMaskerTest extends Specification {
     result == expectedResult
 
     where:
-    payload                                              || expectedResult
-    "\"recipient_verification_answer\":\"an answer\""    || "\"recipient_verification_answer\":\"**MASKED**\""
+    payload || expectedResult
+    "\"recipient_verification_answer\":\"an answer\"" || "\"recipient_verification_answer\":\"**MASKED**\""
     "\"recipient_verification_question\":\"a question\"" || "\"recipient_verification_question\":\"**MASKED**\""
   }
 
@@ -549,7 +549,7 @@ class MdxLogMaskerTest extends Specification {
     result == expectedResult
 
     where:
-    payload                            || expectedResult
+    payload || expectedResult
     "\"account_number\":\"123456789\"" || "\"account_number\":\"**MASKED**\""
   }
 
@@ -562,9 +562,9 @@ class MdxLogMaskerTest extends Specification {
     result == expectedResult
 
     where:
-    payload                                      || expectedResult
-    "\"account_id\":\"ACCOUNT-123\""             || "\"account_id\":\"**MASKED**\""
-    "\"memo\":\"Test memo\""                     || "\"memo\":\"**MASKED**\""
+    payload || expectedResult
+    "\"account_id\":\"ACCOUNT-123\"" || "\"account_id\":\"**MASKED**\""
+    "\"memo\":\"Test memo\"" || "\"memo\":\"**MASKED**\""
     "\"routing_transit_number\":\"0260-0959-3\"" || "\"routing_transit_number\":\"**MASKED**\""
   }
 
@@ -577,9 +577,9 @@ class MdxLogMaskerTest extends Specification {
     result == expectedResult
 
     where:
-    payload                          || expectedResult
+    payload || expectedResult
     "\"account_id\":\"ACCOUNT-123\"" || "\"account_id\":\"**MASKED**\""
-    "\"memo\":\"Test memo\""         || "\"memo\":\"**MASKED**\""
+    "\"memo\":\"Test memo\"" || "\"memo\":\"**MASKED**\""
   }
 
   @Unroll
@@ -591,7 +591,7 @@ class MdxLogMaskerTest extends Specification {
     result == expectedResult
 
     where:
-    payload                      || expectedResult
+    payload || expectedResult
     "\"answer\":\"Test answer\"" || "\"answer\":\"**MASKED**\""
   }
 
@@ -604,11 +604,11 @@ class MdxLogMaskerTest extends Specification {
     result == expectedResult
 
     where:
-    payload                                          || expectedResult
-    "\"account_id\":\"ACCOUNT-123\""                 || "\"account_id\":\"**MASKED**\""
-    "\"challenge_answer\":\"Test answer\""           || "\"challenge_answer\":\"**MASKED**\""
-    "\"memo\":\"Test memo\""                         || "\"memo\":\"**MASKED**\""
-    "\"sender_name\":\"John Doe\""                   || "\"sender_name\":\"**MASKED**\""
+    payload || expectedResult
+    "\"account_id\":\"ACCOUNT-123\"" || "\"account_id\":\"**MASKED**\""
+    "\"challenge_answer\":\"Test answer\"" || "\"challenge_answer\":\"**MASKED**\""
+    "\"memo\":\"Test memo\"" || "\"memo\":\"**MASKED**\""
+    "\"sender_name\":\"John Doe\"" || "\"sender_name\":\"**MASKED**\""
     "\"token\":\"f48c8aa0e66d4d53979b36c4c46c8abc\"" || "\"token\":\"**MASKED**\""
   }
 
@@ -621,9 +621,9 @@ class MdxLogMaskerTest extends Specification {
     result == expectedResult
 
     where:
-    payload                                      || expectedResult
+    payload || expectedResult
     "\"email_address\":\"john.doe@example.com\"" || "\"email_address\":\"**MASKED**\""
-    "\"phone_number\":\"1-222-333-4444\""        || "\"phone_number\":\"**MASKED**\""
+    "\"phone_number\":\"1-222-333-4444\"" || "\"phone_number\":\"**MASKED**\""
   }
 
   @Unroll
@@ -635,9 +635,9 @@ class MdxLogMaskerTest extends Specification {
     result == expectedResult
 
     where:
-    payload                                || expectedResult
-    "\"account_number\":\"1234567890\""    || "\"account_number\":\"**MASKED**\""
-    "\"routing_number\":\"121122676\""     || "\"routing_number\":\"**MASKED**\""
+    payload || expectedResult
+    "\"account_number\":\"1234567890\"" || "\"account_number\":\"**MASKED**\""
+    "\"routing_number\":\"121122676\"" || "\"routing_number\":\"**MASKED**\""
     "\"send_to\":\"john.doe@example.com\"" || "\"send_to\":\"**MASKED**\""
   }
 
@@ -650,9 +650,9 @@ class MdxLogMaskerTest extends Specification {
     result == expectedResult
 
     where:
-    payload                          || expectedResult
+    payload || expectedResult
     "\"account_id\":\"ACCOUNT-123\"" || "\"account_id\":\"**MASKED**\""
-    "\"memo\":\"Test memo\""         || "\"memo\":\"**MASKED**\""
+    "\"memo\":\"Test memo\"" || "\"memo\":\"**MASKED**\""
   }
 
   @Unroll
@@ -664,7 +664,7 @@ class MdxLogMaskerTest extends Specification {
     result == expectedResult
 
     where:
-    payload                                      || expectedResult
+    payload || expectedResult
     "\"email_address\":\"john.doe@example.com\"" || "\"email_address\":\"**MASKED**\""
   }
 
@@ -677,7 +677,7 @@ class MdxLogMaskerTest extends Specification {
     result == expectedResult
 
     where:
-    payload                      || expectedResult
+    payload || expectedResult
     "\"answer\":\"Test answer\"" || "\"answer\":\"**MASKED**\""
   }
 
@@ -690,9 +690,9 @@ class MdxLogMaskerTest extends Specification {
     result == expectedResult
 
     where:
-    payload                   || expectedResult
+    payload || expectedResult
     "\"first_name\":\"John\"" || "\"first_name\":\"**MASKED**\""
-    "\"last_name\":\"Doe\""   || "\"last_name\":\"**MASKED**\""
+    "\"last_name\":\"Doe\"" || "\"last_name\":\"**MASKED**\""
   }
 
   @Unroll
@@ -704,10 +704,10 @@ class MdxLogMaskerTest extends Specification {
     result == expectedResult
 
     where:
-    payload                                          || expectedResult
-    "\"account_id\":\"ACCOUNT-123\""                 || "\"account_id\":\"**MASKED**\""
-    "\"challenge_answer\":\"Test answer\""           || "\"challenge_answer\":\"**MASKED**\""
-    "\"memo\":\"Test memo\""                         || "\"memo\":\"**MASKED**\""
+    payload || expectedResult
+    "\"account_id\":\"ACCOUNT-123\"" || "\"account_id\":\"**MASKED**\""
+    "\"challenge_answer\":\"Test answer\"" || "\"challenge_answer\":\"**MASKED**\""
+    "\"memo\":\"Test memo\"" || "\"memo\":\"**MASKED**\""
     "\"token\":\"41bb602a0ab44896ad28d7de270e24ce\"" || "\"token\":\"**MASKED**\""
   }
 
@@ -720,14 +720,14 @@ class MdxLogMaskerTest extends Specification {
     result == expectedResult
 
     where:
-    payload                                                 || expectedResult
-    "\"account_id\":\"ACCOUNT-123\""                        || "\"account_id\":\"**MASKED**\""
+    payload || expectedResult
+    "\"account_id\":\"ACCOUNT-123\"" || "\"account_id\":\"**MASKED**\""
     "\"address_line_one\":\"3401 N Thanksgiving Way #500\"" || "\"address_line_one\":\"**MASKED**\""
-    "\"address_line_two\":\"Test address line 2\""          || "\"address_line_two\":\"**MASKED**\""
-    "\"city\":\"Lehi\""                                     || "\"city\":\"**MASKED**\""
-    "\"country\":\"US\""                                    || "\"country\":\"**MASKED**\""
-    "\"postal_code\":\"84043\""                             || "\"postal_code\":\"**MASKED**\""
-    "\"state\":\"UT\""                                      || "\"state\":\"**MASKED**\""
+    "\"address_line_two\":\"Test address line 2\"" || "\"address_line_two\":\"**MASKED**\""
+    "\"city\":\"Lehi\"" || "\"city\":\"**MASKED**\""
+    "\"country\":\"US\"" || "\"country\":\"**MASKED**\""
+    "\"postal_code\":\"84043\"" || "\"postal_code\":\"**MASKED**\""
+    "\"state\":\"UT\"" || "\"state\":\"**MASKED**\""
   }
 
   @Unroll
@@ -739,7 +739,7 @@ class MdxLogMaskerTest extends Specification {
     result == expectedResult
 
     where:
-    payload                                      || expectedResult
+    payload || expectedResult
     "\"email_address\":\"john.doe@example.com\"" || "\"email_address\":\"**MASKED**\""
   }
 
@@ -752,9 +752,9 @@ class MdxLogMaskerTest extends Specification {
     result == expectedResult
 
     where:
-    payload                               || expectedResult
+    payload || expectedResult
     "\"current_password\":\"topsecret1\"" || "\"current_password\":\"**MASKED**\""
-    "\"new_password\":\"topsecret2\""     || "\"new_password\":\"**MASKED**\""
+    "\"new_password\":\"topsecret2\"" || "\"new_password\":\"**MASKED**\""
   }
 
   @Unroll
@@ -766,7 +766,7 @@ class MdxLogMaskerTest extends Specification {
     result == expectedResult
 
     where:
-    payload                        || expectedResult
+    payload || expectedResult
     "\"new_username\":\"johndoe\"" || "\"new_username\":\"**MASKED**\""
   }
 
@@ -779,9 +779,9 @@ class MdxLogMaskerTest extends Specification {
     result == expectedResult
 
     where:
-    payload                               || expectedResult
+    payload || expectedResult
     "\"phone_number\":\"1-222-333-4444\"" || "\"phone_number\":\"**MASKED**\""
-    "\"work_extension\":\"1234\""         || "\"work_extension\":\"**MASKED**\""
+    "\"work_extension\":\"1234\"" || "\"work_extension\":\"**MASKED**\""
   }
 
   @Unroll
@@ -793,13 +793,13 @@ class MdxLogMaskerTest extends Specification {
     result == expectedResult
 
     where:
-    payload                            || expectedResult
+    payload || expectedResult
     "\"birth_date_on\":\"2015-01-01\"" || "\"birth_date_on\":\"**MASKED**\""
-    "\"first_name\":\"John\""          || "\"first_name\":\"**MASKED**\""
-    "\"gender\":\"MALE\""              || "\"gender\":\"**MASKED**\""
-    "\"last_name\":\"Doe\""            || "\"last_name\":\"**MASKED**\""
-    "\"middle_name\":\"William\""      || "\"middle_name\":\"**MASKED**\""
-    "\"ssn\":\"123456789\""            || "\"ssn\":\"**MASKED**\""
+    "\"first_name\":\"John\"" || "\"first_name\":\"**MASKED**\""
+    "\"gender\":\"MALE\"" || "\"gender\":\"**MASKED**\""
+    "\"last_name\":\"Doe\"" || "\"last_name\":\"**MASKED**\""
+    "\"middle_name\":\"William\"" || "\"middle_name\":\"**MASKED**\""
+    "\"ssn\":\"123456789\"" || "\"ssn\":\"**MASKED**\""
   }
 
   @Unroll
@@ -811,11 +811,11 @@ class MdxLogMaskerTest extends Specification {
     result == expectedResult
 
     where:
-    payload                                                                        || expectedResult
-    "\"account_id\":\"Account-123\""                                               || "\"account_id\":\"**MASKED**\""
-    "\"back_of_check_image\":\"data:image/png;base64,iVBORw0KGAAAUAAAAFCJggg==\""  || "\"back_of_check_image\":\"**MASKED**\""
+    payload || expectedResult
+    "\"account_id\":\"Account-123\"" || "\"account_id\":\"**MASKED**\""
+    "\"back_of_check_image\":\"data:image/png;base64,iVBORw0KGAAAUAAAAFCJggg==\"" || "\"back_of_check_image\":\"**MASKED**\""
     "\"front_of_check_image\":\"data:image/png;base64,iVBORw0KGAAAUAAAAFCJggg==\"" || "\"front_of_check_image\":\"**MASKED**\""
-    "\"memo\":\"Test memo\""                                                       || "\"memo\":\"**MASKED**\""
+    "\"memo\":\"Test memo\"" || "\"memo\":\"**MASKED**\""
   }
 
   @Unroll
@@ -827,7 +827,7 @@ class MdxLogMaskerTest extends Specification {
     result == expectedResult
 
     where:
-    payload                          || expectedResult
+    payload || expectedResult
     "\"account_id\":\"Account-123\"" || "\"account_id\":\"**MASKED**\""
   }
 
@@ -840,9 +840,9 @@ class MdxLogMaskerTest extends Specification {
     result == expectedResult
 
     where:
-    payload                               || expectedResult
+    payload || expectedResult
     "\"from_account_id\":\"Account-123\"" || "\"from_account_id\":\"**MASKED**\""
-    "\"to_account_id\":\"Account-456\""   || "\"to_account_id\":\"**MASKED**\""
+    "\"to_account_id\":\"Account-456\"" || "\"to_account_id\":\"**MASKED**\""
   }
 
   @Unroll
@@ -854,10 +854,10 @@ class MdxLogMaskerTest extends Specification {
     result == expectedResult
 
     where:
-    payload                               || expectedResult
+    payload || expectedResult
     "\"from_account_id\":\"Account-123\"" || "\"from_account_id\":\"**MASKED**\""
-    "\"memo\":\"Test memo\""              || "\"memo\":\"**MASKED**\""
-    "\"to_account_id\":\"Account-456\""   || "\"to_account_id\":\"**MASKED**\""
+    "\"memo\":\"Test memo\"" || "\"memo\":\"**MASKED**\""
+    "\"to_account_id\":\"Account-456\"" || "\"to_account_id\":\"**MASKED**\""
   }
 
   @Unroll
@@ -869,11 +869,11 @@ class MdxLogMaskerTest extends Specification {
     result == expectedResult
 
     where:
-    payload                                    || expectedResult
-    "\"from_account_id\":\"Account-123\""      || "\"from_account_id\":\"**MASKED**\""
-    "\"memo\":\"Test memo\""                   || "\"memo\":\"**MASKED**\""
+    payload || expectedResult
+    "\"from_account_id\":\"Account-123\"" || "\"from_account_id\":\"**MASKED**\""
+    "\"memo\":\"Test memo\"" || "\"memo\":\"**MASKED**\""
     "\"repayment_account_id\":\"Account-456\"" || "\"repayment_account_id\":\"**MASKED**\""
-    "\"to_account_id\":\"Account-789\""        || "\"to_account_id\":\"**MASKED**\""
+    "\"to_account_id\":\"Account-789\"" || "\"to_account_id\":\"**MASKED**\""
   }
 
   @Unroll
@@ -885,8 +885,8 @@ class MdxLogMaskerTest extends Specification {
     result == expectedResult
 
     where:
-    payload                                      || expectedResult
+    payload || expectedResult
     "\"destination_account_id\":\"Account-123\"" || "\"destination_account_id\":\"**MASKED**\""
-    "\"source_account_id\":\"Account-456\""      || "\"source_account_id\":\"**MASKED**\""
+    "\"source_account_id\":\"Account-456\"" || "\"source_account_id\":\"**MASKED**\""
   }
 }

--- a/mdx-models/src/test/groovy/com/mx/path/model/mdx/model/ondemand/MdxOnDemandMdxListSerializerTest.groovy
+++ b/mdx-models/src/test/groovy/com/mx/path/model/mdx/model/ondemand/MdxOnDemandMdxListSerializerTest.groovy
@@ -52,7 +52,7 @@ class MdxOnDemandMdxListSerializerTest extends MockeryAndSessionRepository {
     generator.flush()
 
     then:
-    def expectedResponse= "<Transaction>\n" +
+    def expectedResponse = "<Transaction>\n" +
         "  <amount>9.99</amount>\n" +
         "  <description>Fees</description>\n" +
         "  <id>T-123</id>\n" +
@@ -85,7 +85,7 @@ class MdxOnDemandMdxListSerializerTest extends MockeryAndSessionRepository {
     generator.flush()
 
     then:
-    def expectedResponse= "<mdx version=\"5.0\">\n" +
+    def expectedResponse = "<mdx version=\"5.0\">\n" +
         "<transactions>\n</transactions>\n" +
         "</mdx>\n"
 
@@ -112,7 +112,7 @@ class MdxOnDemandMdxListSerializerTest extends MockeryAndSessionRepository {
     generator.flush()
 
     then:
-    def expectedResponse= "<mdx version=\"5.0\">\n" +
+    def expectedResponse = "<mdx version=\"5.0\">\n" +
         "<transactions>\n" +
         "<Transaction>\n" +
         "  <amount>9.99</amount>\n" +
@@ -155,7 +155,7 @@ class MdxOnDemandMdxListSerializerTest extends MockeryAndSessionRepository {
     subject.serialize(list, generator, (SerializationContext) null)
 
     then:
-    def expectedResponse= "<mdx version=\"5.0\">\n" +
+    def expectedResponse = "<mdx version=\"5.0\">\n" +
         "<accounts>\n" +
         "<account>\n" +
         "  <balance>9.99</balance>\n" +

--- a/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/DateVersionedResponseTest.groovy
+++ b/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/DateVersionedResponseTest.groovy
@@ -173,10 +173,10 @@ class DateVersionedResponseTest extends Specification implements WithMockery {
     versionedExecuted == versionShouldBeExecuted
 
     where:
-    contentType                                    || accept                                         || defaultShouldBeExecuted || versionShouldBeExecuted
-    "application/vnd.mdx.v6+json"                  || "application/vnd.mdx.v6+json"                  || true                    || false
-    "application/vnd.mdx.v6+json;version=20240101" || "application/vnd.mdx.v6+json"                  || false                   || true
-    "application/vnd.mdx.v6+json"                  || "application/vnd.mdx.v6+json;version=20240101" || false                   || true
+    contentType || accept || defaultShouldBeExecuted || versionShouldBeExecuted
+    "application/vnd.mdx.v6+json" || "application/vnd.mdx.v6+json" || true || false
+    "application/vnd.mdx.v6+json;version=20240101" || "application/vnd.mdx.v6+json" || false || true
+    "application/vnd.mdx.v6+json" || "application/vnd.mdx.v6+json;version=20240101" || false || true
   }
 
   def buildRequest(Object body, String contentType, String accept = null) {

--- a/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/ExceptionResolverWebMvcConfigurerTest.groovy
+++ b/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/ExceptionResolverWebMvcConfigurerTest.groovy
@@ -53,11 +53,11 @@ class ExceptionResolverWebMvcConfigurerTest extends Specification {
     response.status == expectedStatus
 
     where:
-    exception                                      | expectNullMav | expectedStatus
-    new EOFException()                             | true          | 200
-    new IOException("Broken pipe")                 | true          | 200
-    new IOException("Connection reset by peer")    | true          | 200
-    new ConnectException("", new EOFException())   | true          | 200
-    new TypeMismatchException("bad value", String) | false         | 400
+    exception | expectNullMav | expectedStatus
+    new EOFException() | true | 200
+    new IOException("Broken pipe") | true | 200
+    new IOException("Connection reset by peer") | true | 200
+    new ConnectException("", new EOFException()) | true | 200
+    new TypeMismatchException("bad value", String) | false | 400
   }
 }

--- a/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/AchScheduledTransferFrequenciesControllerTest.groovy
+++ b/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/AchScheduledTransferFrequenciesControllerTest.groovy
@@ -46,7 +46,9 @@ class AchScheduledTransferFrequenciesControllerTest extends Specification implem
     BaseController.setGateway(gateway)
     def frequency = new Frequency()
     def list = new MdxList<Frequency>().tap { add(frequency) }
-    def queryParameters = new AchScheduledTransferFrequencyListQueryParameters().tap { transfer_type = "test" }
+    def queryParameters = new AchScheduledTransferFrequencyListQueryParameters().tap {
+      transfer_type = "test"
+    }
 
     when:
     Mockito.doReturn(new AccessorResponse<MdxList<Frequency>>().withResult(list)).when(achScheduledTransferFrequencyGateway).list(any())

--- a/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/AchTransfersControllerTest.groovy
+++ b/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/AchTransfersControllerTest.groovy
@@ -41,7 +41,9 @@ class AchTransfersControllerTest extends Specification implements WithMockery {
     BaseController.setGateway(gateway)
     def transfers = new MdxList<AchTransfer>()
     transfers.add(new AchTransfer())
-    def queryParameters = new AchTransferListQueryParameters().tap { transfer_type = "test" }
+    def queryParameters = new AchTransferListQueryParameters().tap {
+      transfer_type = "test"
+    }
 
     when:
     Mockito.doReturn(new AccessorResponse<MdxList<AchTransfer>>().withResult(transfers))

--- a/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/AuthenticationControllerTest.groovy
+++ b/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/AuthenticationControllerTest.groovy
@@ -456,7 +456,9 @@ class AuthenticationControllerTest extends Specification implements WithMockery 
     def resultAuthentication = new Authentication()
     resultAuthentication.setChallenges(new ArrayList<MfaChallenge>().tap {
       add(new MfaChallenge().tap {
-        setAuthorization(new Authorization().tap { setUrl("https://someUrlForFederatedLogin.com/") })
+        setAuthorization(new Authorization().tap {
+          setUrl("https://someUrlForFederatedLogin.com/")
+        })
       })
     })
 
@@ -590,7 +592,7 @@ class AuthenticationControllerTest extends Specification implements WithMockery 
     def response = subject.forgotUsername()
 
     then:
-    verify(gateway).id()        || true
+    verify(gateway).id() || true
     verify(id).forgotUsername() || true
     response.statusCode == HttpStatus.OK
   }
@@ -598,7 +600,9 @@ class AuthenticationControllerTest extends Specification implements WithMockery 
   def "forgotUsernameResend - ACCEPTED"() {
     given:
     AuthenticationController.setGateway(gateway)
-    def forgotUsername = new ForgotUsername().tap { setChallenge(getChallenge()) }
+    def forgotUsername = new ForgotUsername().tap {
+      setChallenge(getChallenge())
+    }
     def expected = new ForgotUsername().tap { setChallenge(new Challenge()) }
     doReturn(new AccessorResponse<ForgotUsername>().withResult(expected).withStatus(PathResponseStatus.ACCEPTED)).when(id).answerForgotUsername(forgotUsername)
 
@@ -606,7 +610,7 @@ class AuthenticationControllerTest extends Specification implements WithMockery 
     def response = subject.forgotUsername(forgotUsername)
 
     then:
-    verify(gateway).id()                            || true
+    verify(gateway).id() || true
     verify(id).answerForgotUsername(forgotUsername) || true
     response.statusCode == HttpStatus.ACCEPTED
   }
@@ -614,14 +618,16 @@ class AuthenticationControllerTest extends Specification implements WithMockery 
   def "answerForgotUsername - NO_CONTENT"() {
     given:
     AuthenticationController.setGateway(gateway)
-    def forgotUsername = new ForgotUsername().tap { setChallenge(getChallenge()) }
+    def forgotUsername = new ForgotUsername().tap {
+      setChallenge(getChallenge())
+    }
     doReturn(new AccessorResponse<ForgotUsername>().withResult(new ForgotUsername()).withStatus(PathResponseStatus.NO_CONTENT)).when(id).answerForgotUsername(forgotUsername)
 
     when:
     def response = subject.forgotUsername(forgotUsername)
 
     then:
-    verify(gateway).id()                            || true
+    verify(gateway).id() || true
     verify(id).answerForgotUsername(forgotUsername) || true
     response.statusCode == HttpStatus.NO_CONTENT
   }
@@ -635,7 +641,7 @@ class AuthenticationControllerTest extends Specification implements WithMockery 
     def response = subject.resetPassword()
 
     then:
-    verify(gateway).id()       || true
+    verify(gateway).id() || true
     verify(id).resetPassword() || true
     response.statusCode == HttpStatus.OK
   }
@@ -651,7 +657,7 @@ class AuthenticationControllerTest extends Specification implements WithMockery 
     def response = subject.resetPassword(resetPassword)
 
     then:
-    verify(gateway).id()                          || true
+    verify(gateway).id() || true
     verify(id).answerResetPassword(resetPassword) || true
     response.statusCode == HttpStatus.ACCEPTED
   }
@@ -666,7 +672,7 @@ class AuthenticationControllerTest extends Specification implements WithMockery 
     def response = subject.resetPassword(resetPassword)
 
     then:
-    verify(gateway).id()                          || true
+    verify(gateway).id() || true
     verify(id).answerResetPassword(resetPassword) || true
     response.statusCode == HttpStatus.NO_CONTENT
   }
@@ -710,7 +716,7 @@ class AuthenticationControllerTest extends Specification implements WithMockery 
     def response = subject.unlockUser(unlockUser)
 
     then:
-    verify(gateway).id()              || true
+    verify(gateway).id() || true
     verify(id).unlockUser(unlockUser) || true
     response.statusCode == HttpStatus.ACCEPTED
     response.getBody().challenges.size() > 0
@@ -726,7 +732,7 @@ class AuthenticationControllerTest extends Specification implements WithMockery 
     def response = subject.unlockUser(unlockUser)
 
     then:
-    verify(gateway).id()              || true
+    verify(gateway).id() || true
     verify(id).unlockUser(unlockUser) || true
     response.statusCode == HttpStatus.NO_CONTENT
   }

--- a/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/CheckImagesControllerTest.groovy
+++ b/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/CheckImagesControllerTest.groovy
@@ -10,14 +10,13 @@ import com.mx.path.gateway.api.Gateway
 import com.mx.path.gateway.api.account.AccountGateway
 import com.mx.path.gateway.api.account.CheckImageGateway
 import com.mx.path.gateway.api.account.TransactionGateway
+import com.mx.path.model.mdx.model.check.CheckImage
 import com.mx.path.model.mdx.web.model.check_image.CheckImagesGetQueryParameters
 import com.mx.path.testing.WithMockery
 
 import org.springframework.http.HttpStatus
 
 import spock.lang.Specification
-
-import  com.mx.path.model.mdx.model.check.CheckImage
 
 class CheckImagesControllerTest extends Specification implements WithMockery{
   CheckImagesController subject

--- a/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/CrossAccountRecurringTransferControllerTest.groovy
+++ b/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/CrossAccountRecurringTransferControllerTest.groovy
@@ -70,7 +70,9 @@ class CrossAccountRecurringTransferControllerTest extends Specification{
     BaseController.setGateway(gateway)
 
     def crossAccountRecurringTransfer = new CrossAccountRecurringTransfer()
-    def list = new MdxList<CrossAccountRecurringTransfer>().tap { add(crossAccountRecurringTransfer) }
+    def list = new MdxList<CrossAccountRecurringTransfer>().tap {
+      add(crossAccountRecurringTransfer)
+    }
 
     when:
     Mockito.doReturn(new AccessorResponse<MdxList<CrossAccountRecurringTransfer>>().withResult(list)).when(crossAccountRecurringTransferGateway).list()
@@ -102,7 +104,7 @@ class CrossAccountRecurringTransferControllerTest extends Specification{
     BaseController.setGateway(gateway)
 
     when:
-    Mockito.doReturn(new AccessorResponse<Void>()).when(crossAccountRecurringTransferGateway).delete ("id")
+    Mockito.doReturn(new AccessorResponse<Void>()).when(crossAccountRecurringTransferGateway).delete("id")
     def response = subject.deleteCrossAccountRecurringTransfer("id")
 
     then:
@@ -117,7 +119,7 @@ class CrossAccountRecurringTransferControllerTest extends Specification{
 
     when:
     Mockito.doReturn(new AccessorResponse<CrossAccountRecurringTransfer>().withResult(crossAccountRecurringTransfer))
-        .when(crossAccountRecurringTransferGateway).skipNext ("id")
+        .when(crossAccountRecurringTransferGateway).skipNext("id")
     def response = subject.skipCrossAccountRecurringTransfer("id")
 
     then:

--- a/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/CrossAccountTransferDestinationControllerTest.groovy
+++ b/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/CrossAccountTransferDestinationControllerTest.groovy
@@ -15,7 +15,7 @@ import org.springframework.http.HttpStatus
 
 import spock.lang.Specification
 
-class CrossAccountTransferDestinationControllerTest  extends Specification {
+class CrossAccountTransferDestinationControllerTest extends Specification {
   CrossAccountTransferDestinationController subject
   Gateway gateway
   CrossAccountTransferGateway crossAccountTransferGateway

--- a/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/CrossAccountTransfersControllerTest.groovy
+++ b/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/CrossAccountTransfersControllerTest.groovy
@@ -89,7 +89,9 @@ class CrossAccountTransfersControllerTest extends Specification implements WithM
     given:
     BaseController.setGateway(gateway)
     def crossAccountTransfer = new CrossAccountTransfer()
-    def crossAccountTransfers = new MdxList<CrossAccountTransfer>().tap { add(crossAccountTransfer) }
+    def crossAccountTransfers = new MdxList<CrossAccountTransfer>().tap {
+      add(crossAccountTransfer)
+    }
 
     when:
     Mockito.doReturn(new AccessorResponse<MdxList<CrossAccountTransfer>>().withResult(crossAccountTransfers)).when(crossAccountTransferGateway).list()

--- a/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/DisputedTransactionsControllerTest.groovy
+++ b/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/DisputedTransactionsControllerTest.groovy
@@ -93,7 +93,9 @@ class DisputedTransactionsControllerTest extends Specification {
   def "listDisputedTransactions interacts with gateway"() {
     given:
     def disputeId = "4321"
-    def disputedTransactions = new MdxList<DisputedTransaction>().tap {add(new DisputedTransaction()) }
+    def disputedTransactions = new MdxList<DisputedTransaction>().tap {
+      add(new DisputedTransaction())
+    }
     BaseController.setGateway(gateway)
     doReturn(new AccessorResponse<MdxList<DisputedTransaction>>().withResult(disputedTransactions)).when(disputedTransactionGateway).list(disputeId)
 

--- a/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/OriginationsControllerTest.groovy
+++ b/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/OriginationsControllerTest.groovy
@@ -44,7 +44,9 @@ class OriginationsControllerTest extends Specification {
 
   def "start interacts with gateway"() {
     given:
-    def origination = new Origination().tap { setChallenges(Arrays.asList(new Challenge())) }
+    def origination = new Origination().tap {
+      setChallenges(Arrays.asList(new Challenge()))
+    }
     doReturn(new AccessorResponse<Origination>().withResult(origination)).when(originationGateway).start()
 
     when:
@@ -118,7 +120,9 @@ class OriginationsControllerTest extends Specification {
   def "authenticated user start interacts with gateway"() {
     given:
     initActiveSession()
-    def origination = new Origination().tap { setChallenges(Arrays.asList(new Challenge())) }
+    def origination = new Origination().tap {
+      setChallenges(Arrays.asList(new Challenge()))
+    }
     doReturn(new AccessorResponse<Origination>().withResult(origination)).when(originationGateway).authenticatedUserStart(any())
 
     when:

--- a/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/ProfilesControllerTest.groovy
+++ b/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/ProfilesControllerTest.groovy
@@ -738,7 +738,7 @@ class ProfilesControllerTest extends Specification {
     doReturn(mockResponse).when(profileGateway).updateUserNameWithMFA(any())
 
     when:
-    def response = subject.updateUserNameWithMFA(new NewUserName()  )
+    def response = subject.updateUserNameWithMFA(new NewUserName())
 
     then:
     response.body == mockResponse.result

--- a/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/RecurringTransfersControllerTest.groovy
+++ b/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/RecurringTransfersControllerTest.groovy
@@ -97,7 +97,9 @@ class RecurringTransfersControllerTest extends Specification implements WithMock
     BaseController.setGateway(gateway)
     def transfer = new RecurringTransfer()
     def list = new MdxList<RecurringTransfer>().tap { add(transfer) }
-    def queryParameters = new RecurringTransferListQueryParameters().tap { transfer_type = "test" }
+    def queryParameters = new RecurringTransferListQueryParameters().tap {
+      transfer_type = "test"
+    }
 
     when:
     Mockito.doReturn(new AccessorResponse<MdxList<RecurringTransfer>>().withResult(list)).when(recurringTransferGateway).list(any(RecurringTransferListOptions))

--- a/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/TransfersControllerTest.groovy
+++ b/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/TransfersControllerTest.groovy
@@ -86,7 +86,9 @@ class TransfersControllerTest extends Specification {
     BaseController.setGateway(gateway)
     def transfer = new Transfer()
     def list = new MdxList<Transfer>().tap { add(transfer) }
-    def queryParameters = new TransferListQueryParameters().tap { transfer_type = "test"}
+    def queryParameters = new TransferListQueryParameters().tap {
+      transfer_type = "test"
+    }
 
     when:
     Mockito.doReturn(new AccessorResponse<MdxList<Transfer>>().withResult(list)).when(transferGateway).list(any(TransferListOptions))

--- a/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/VerificationMethodsControllerTest.groovy
+++ b/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/controller/VerificationMethodsControllerTest.groovy
@@ -37,7 +37,9 @@ class VerificationMethodsControllerTest extends Specification {
     BaseController.setGateway(gateway)
 
     def verificationMethod = new VerificationMethod()
-    def verificationMethods = new MdxList<VerificationMethod>().tap { add(verificationMethod) }
+    def verificationMethods = new MdxList<VerificationMethod>().tap {
+      add(verificationMethod)
+    }
 
     when:
     Mockito.doReturn(new AccessorResponse<MdxList<VerificationMethod>>().withResult(verificationMethods)).when(verificationMethodGateway).list()

--- a/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/filter/ErrorHandlerFilterTest.groovy
+++ b/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/filter/ErrorHandlerFilterTest.groovy
@@ -51,7 +51,9 @@ class ErrorHandlerFilterTest extends Specification {
     subject.doFilter(request, response, filterChain)
 
     then:
-    1 * outputStream.write(_) >> { args -> responseBody = new String((byte[]) args[0]) }
+    1 * outputStream.write(_) >> { args ->
+      responseBody = new String((byte[]) args[0])
+    }
     responseBody == '{"error":{"message":"Danger!","user_message":"Danger"}}'
   }
 
@@ -66,7 +68,9 @@ class ErrorHandlerFilterTest extends Specification {
     subject.doFilter(request, response, filterChain)
 
     then:
-    1 * outputStream.write(_) >> { args -> responseBody = new String((byte[]) args[0]) }
+    1 * outputStream.write(_) >> { args ->
+      responseBody = new String((byte[]) args[0])
+    }
     responseBody == '{"error":{"message":"Danger!","user_message":"Danger!"}}'
   }
 
@@ -81,7 +85,9 @@ class ErrorHandlerFilterTest extends Specification {
     subject.doFilter(request, response, filterChain)
 
     then:
-    1 * outputStream.write(_) >> { args -> responseBody = new String((byte[]) args[0]) }
+    1 * outputStream.write(_) >> { args ->
+      responseBody = new String((byte[]) args[0])
+    }
     responseBody == '{"error":{"message":"Danger!","user_message":"Danger!","error_code":"4011"}}'
   }
 
@@ -96,7 +102,9 @@ class ErrorHandlerFilterTest extends Specification {
     subject.doFilter(request, response, filterChain)
 
     then:
-    1 * outputStream.write(_) >> { args -> responseBody = new String((byte[]) args[0]) }
+    1 * outputStream.write(_) >> { args ->
+      responseBody = new String((byte[]) args[0])
+    }
     responseBody == '{"error":{"message":"Danger!","user_message":"Danger!","error_title":"errorTitle","error_code":"4011"}}'
   }
 

--- a/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/filter/PathRequestLoggingFilterTest.groovy
+++ b/mdx-web/src/test/groovy/com/mx/path/model/mdx/web/filter/PathRequestLoggingFilterTest.groovy
@@ -219,9 +219,9 @@ class PathRequestLoggingFilterTest extends Specification {
     verify(subject, never()).logRequest(any(ContentCachingRequestWrapper), any(ContentCachingResponseWrapper), anyLong()) || true
 
     where:
-    request_uri                               || _
+    request_uri || _
     "http://10.66.90.77:3000/actuator/health" || _
-    "path-connector-<client-id>/status"       || _
+    "path-connector-<client-id>/status" || _
   }
 
   private class PathRequestLoggingFilterWithNoMDCClearing extends PathRequestLoggingFilter {

--- a/realtime/src/test/groovy/com/mx/path/service/connection/realtime/model/MdxUserTest.groovy
+++ b/realtime/src/test/groovy/com/mx/path/service/connection/realtime/model/MdxUserTest.groovy
@@ -54,7 +54,9 @@ class MdxUserTest extends Specification {
   def "getMetadataField String"() {
     given:
     def fingerprint = "U-12345"
-    def mdxUser = new MdxUser().tap { setMetadataField("fingerprint", fingerprint) }
+    def mdxUser = new MdxUser().tap {
+      setMetadataField("fingerprint", fingerprint)
+    }
 
     when:
     def result = mdxUser.getMetadataField("fingerprint")
@@ -72,17 +74,19 @@ class MdxUserTest extends Specification {
     mdxUser.getMetadataField("someValue", klass) == value
 
     where:
-    klass   || value
+    klass || value
     Boolean || true
     Integer || 1
-    Double  || 2.0
-    String  || "hello"
+    Double || 2.0
+    String || "hello"
   }
 
   def "getMetadataField for complex object"() {
     given:
     def remoteUser = new RemoteUser().tap { setLastName("Doe")}
-    def mdxUser = new MdxUser().tap { setMetadataField("someValue", remoteUser) }
+    def mdxUser = new MdxUser().tap {
+      setMetadataField("someValue", remoteUser)
+    }
 
     when:
     def result = mdxUser.getMetadataField("someValue", RemoteUser)


### PR DESCRIPTION
# Summary of Changes

Adds `confirmationId` to the `AchTransfer` model to support returning a confirmation ID that matches the id field from GCU Path.

Fixes # (issue)

## Public API Additions/Changes

Added `confirmationId` (String) field to `AchTransfer`.

## Downstream Consumer Impact

Non-breaking addition. Downstream consumers will have access to a new `confirmation_id` field on ACH transfer responses. No migration required.


# How Has This Been Tested?
No new tests required — field addition follows existing model conventions and no masking logic applies.

- [ ] Test A
- [ ] Test B

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
